### PR TITLE
Add MPLS support

### DIFF
--- a/common/mpls.cpp
+++ b/common/mpls.cpp
@@ -89,11 +89,6 @@ AbstractProtocol::FieldFlags MplsProtocol::fieldFlags(int index) const
         case mpls_ttl:
             break;
 
-        case mpls_is_override_bos:
-            flags &= ~FrameField;
-            flags |= MetaField;
-            break;
-
         default:
             qFatal("%s: unimplemented case %d in switch", __PRETTY_FUNCTION__,
                 index);
@@ -159,11 +154,7 @@ QVariant MplsProtocol::fieldData(int index, FieldAttrib attrib,
         }
         case mpls_bos:
         {
-            int bos;
-            if(data.is_override_bos())
-                bos = data.bos();
-            else
-                bos = !(next &&
+            int bos = !(next &&
                         next->protocolNumber() ==
                                 MplsProtocol::protocolNumber());
 
@@ -200,19 +191,6 @@ QVariant MplsProtocol::fieldData(int index, FieldAttrib attrib,
                     return QByteArray(1, (char) ttl);
                 case FieldBitSize:
                     return 8;
-                default:
-                    break;
-            }
-            break;
-        }
-
-        // Meta fields
-        case mpls_is_override_bos:
-        {
-            switch(attrib)
-            {
-                case FieldValue:
-                    return data.is_override_bos();
                 default:
                     break;
             }
@@ -264,15 +242,6 @@ bool MplsProtocol::setFieldData(int index, const QVariant &value,
             uint ttl = value.toUInt(&isOk);
             if (isOk)
                 data.set_ttl(ttl);
-            break;
-        }
-
-        // Meta-fields
-        case mpls_is_override_bos:
-        {
-            bool isOverrideBos = value.toBool();
-            data.set_is_override_bos(isOverrideBos);
-            isOk = true;
             break;
         }
 

--- a/common/mpls.cpp
+++ b/common/mpls.cpp
@@ -1,0 +1,296 @@
+/*
+Copyright (C) 2010, 2014 Srivats P.
+Copyright (C) 2015 Ilya Volchanetskiy
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#include "mpls.h"
+
+MplsProtocol::MplsProtocol(StreamBase *stream, AbstractProtocol *parent)
+    : AbstractProtocol(stream, parent)
+{
+}
+
+MplsProtocol::~MplsProtocol()
+{
+}
+
+AbstractProtocol* MplsProtocol::createInstance(StreamBase *stream,
+    AbstractProtocol *parent)
+{
+    return new MplsProtocol(stream, parent);
+}
+
+quint32 MplsProtocol::protocolNumber() const
+{
+    return OstProto::Protocol::kMplsFieldNumber;
+}
+
+void MplsProtocol::protoDataCopyInto(OstProto::Protocol &protocol) const
+{
+    protocol.MutableExtension(OstProto::mpls)->CopyFrom(data);
+    protocol.mutable_protocol_id()->set_id(protocolNumber());
+}
+
+void MplsProtocol::protoDataCopyFrom(const OstProto::Protocol &protocol)
+{
+    if (protocol.protocol_id().id() == protocolNumber() &&
+            protocol.HasExtension(OstProto::mpls))
+        data.MergeFrom(protocol.GetExtension(OstProto::mpls));
+}
+
+QString MplsProtocol::name() const
+{
+    return QString("Multiprotocol Label Switching");
+}
+
+QString MplsProtocol::shortName() const
+{
+    return QString("MPLS");
+}
+
+quint32 MplsProtocol::protocolId(ProtocolIdType type) const
+{
+    switch(type)
+    {
+        case ProtocolIdEth: return 0x8847;
+        default:break;
+    }
+
+    return AbstractProtocol::protocolId(type);
+}
+
+int MplsProtocol::fieldCount() const
+{
+    return mpls_fieldCount;
+}
+
+AbstractProtocol::FieldFlags MplsProtocol::fieldFlags(int index) const
+{
+    AbstractProtocol::FieldFlags flags;
+
+    flags = AbstractProtocol::fieldFlags(index);
+
+    switch (index)
+    {
+        case mpls_label:
+        case mpls_exp:
+        case mpls_bos:
+        case mpls_ttl:
+            break;
+
+        case mpls_is_override_bos:
+            flags &= ~FrameField;
+            flags |= MetaField;
+            break;
+
+        default:
+            qFatal("%s: unimplemented case %d in switch", __PRETTY_FUNCTION__,
+                index);
+            break;
+    }
+
+    return flags;
+}
+
+QVariant MplsProtocol::fieldData(int index, FieldAttrib attrib,
+        int streamIndex) const
+{
+    switch (index)
+    {
+        case mpls_label:
+        {
+            int label = data.label();
+
+            switch(attrib)
+            {
+                case FieldName:
+                    return QString("Label");
+                case FieldValue:
+                    return label;
+                case FieldTextValue:
+                    return QString("%1").arg(label);
+                case FieldFrameValue:
+                {
+                    QByteArray fv;
+                    fv.resize(4);
+                    qToBigEndian((quint32) label, (uchar*) fv.data());
+                    fv.remove(0, 1);
+                    return fv;
+                }
+                case FieldBitSize:
+                    return 20;
+                default:
+                    break;
+            }
+            break;
+
+        }
+        case mpls_exp:
+        {
+            int exp = data.exp();
+
+            switch(attrib)
+            {
+                case FieldName:
+                    return QString("EXP");
+                case FieldValue:
+                    return exp;
+                case FieldTextValue:
+                    return QString("%1").arg(exp);
+                case FieldFrameValue:
+                    return QByteArray(1, (char) exp);
+                case FieldBitSize:
+                    return 3;
+                default:
+                    break;
+            }
+            break;
+        }
+        case mpls_bos:
+        {
+            int bos;
+            if(data.is_override_bos())
+                bos = data.bos();
+            else
+                bos = !(next &&
+                        next->protocolNumber() ==
+                                MplsProtocol::protocolNumber());
+
+            switch(attrib)
+            {
+                case FieldName:
+                    return QString("Bottom of stack");
+                case FieldValue:
+                    return bos;
+                case FieldTextValue:
+                    return QString("%1").arg(bos);
+                case FieldFrameValue:
+                    return QByteArray(1, (char) bos);
+                case FieldBitSize:
+                    return 1;
+                default:
+                    break;
+            }
+            break;
+        }
+        case mpls_ttl:
+        {
+            int ttl = data.ttl();
+
+            switch(attrib)
+            {
+                case FieldName:
+                    return QString("TTL");
+                case FieldValue:
+                    return ttl;
+                case FieldTextValue:
+                    return QString("%1").arg(ttl);
+                case FieldFrameValue:
+                    return QByteArray(1, (char) ttl);
+                case FieldBitSize:
+                    return 8;
+                default:
+                    break;
+            }
+            break;
+        }
+
+        // Meta fields
+        case mpls_is_override_bos:
+        {
+            switch(attrib)
+            {
+                case FieldValue:
+                    return data.is_override_bos();
+                default:
+                    break;
+            }
+            break;
+        }
+
+        default:
+            qFatal("%s: unimplemented case %d in switch", __PRETTY_FUNCTION__,
+                index);
+            break;
+    }
+
+    return AbstractProtocol::fieldData(index, attrib, streamIndex);
+}
+
+bool MplsProtocol::setFieldData(int index, const QVariant &value,
+        FieldAttrib attrib)
+{
+    bool isOk = false;
+
+    if (attrib != FieldValue)
+        goto _exit;
+
+    switch (index)
+    {
+        case mpls_label:
+        {
+            uint label = value.toUInt(&isOk);
+            if (isOk)
+                data.set_label(label);
+            break;
+        }
+        case mpls_exp:
+        {
+            uint exp = value.toUInt(&isOk);
+            if (isOk)
+                data.set_exp(exp);
+            break;
+        }
+        case mpls_bos:
+        {
+            uint bos = value.toUInt(&isOk);
+            if (isOk)
+                data.set_bos(bos);
+            break;
+        }
+        case mpls_ttl:
+        {
+            uint ttl = value.toUInt(&isOk);
+            if (isOk)
+                data.set_ttl(ttl);
+            break;
+        }
+
+        // Meta-fields
+        case mpls_is_override_bos:
+        {
+            bool isOverrideBos = value.toBool();
+            data.set_is_override_bos(isOverrideBos);
+            isOk = true;
+            break;
+        }
+
+        default:
+            qFatal("%s: unimplemented case %d in switch", __PRETTY_FUNCTION__,
+                index);
+            break;
+    }
+
+_exit:
+    return isOk;
+}
+
+int MplsProtocol::protocolFrameVariableCount() const
+{
+    return AbstractProtocol::protocolFrameVariableCount();
+}

--- a/common/mpls.cpp
+++ b/common/mpls.cpp
@@ -25,10 +25,6 @@ MplsProtocol::MplsProtocol(StreamBase *stream, AbstractProtocol *parent)
 {
 }
 
-MplsProtocol::~MplsProtocol()
-{
-}
-
 AbstractProtocol* MplsProtocol::createInstance(StreamBase *stream,
     AbstractProtocol *parent)
 {
@@ -288,9 +284,4 @@ bool MplsProtocol::setFieldData(int index, const QVariant &value,
 
 _exit:
     return isOk;
-}
-
-int MplsProtocol::protocolFrameVariableCount() const
-{
-    return AbstractProtocol::protocolFrameVariableCount();
 }

--- a/common/mpls.h
+++ b/common/mpls.h
@@ -1,0 +1,83 @@
+/*
+Copyright (C) 2010, 2014 Srivats P.
+Copyright (C) 2015 Ilya Volchanetskiy
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#ifndef _MPLS_H
+#define _MPLS_H
+
+#include "abstractprotocol.h"
+#include "mpls.pb.h"
+
+/* 
+MPLS Protocol Frame Format -
+    +-------+-----+-----+-----+
+    | Label | EXP | BoS | TTL |
+    | (20)  | (3) | (1) | (8) |
+    +-------+-----+-----+-----+
+Figures in brackets represent field width in bits
+*/
+
+class MplsProtocol : public AbstractProtocol
+{
+public:
+    enum mplsfield
+    {
+        // Frame Fields
+        mpls_label = 0,
+        mpls_exp,
+        mpls_bos,
+        mpls_ttl,
+
+        // Meta Fields
+        mpls_is_override_bos,
+
+        mpls_fieldCount
+    };
+
+    MplsProtocol(StreamBase *stream, AbstractProtocol *parent = 0);
+    virtual ~MplsProtocol();
+
+    static AbstractProtocol* createInstance(StreamBase *stream,
+        AbstractProtocol *parent = 0);
+    virtual quint32 protocolNumber() const;
+
+    virtual void protoDataCopyInto(OstProto::Protocol &protocol) const;
+    virtual void protoDataCopyFrom(const OstProto::Protocol &protocol);
+
+    virtual quint32 protocolId(ProtocolIdType type) const;
+
+    virtual QString name() const;
+    virtual QString shortName() const;
+
+    virtual int fieldCount() const;
+
+    virtual AbstractProtocol::FieldFlags fieldFlags(int index) const;
+    virtual QVariant fieldData(int index, FieldAttrib attrib,
+               int streamIndex = 0) const;
+    virtual bool setFieldData(int index, const QVariant &value, 
+            FieldAttrib attrib = FieldValue);
+
+
+    virtual int protocolFrameVariableCount() const;
+
+private:
+    OstProto::Mpls    data;
+};
+
+#endif

--- a/common/mpls.h
+++ b/common/mpls.h
@@ -45,8 +45,6 @@ public:
         mpls_ttl,
 
         // Meta Fields
-        mpls_is_override_bos,
-
         mpls_fieldCount
     };
 

--- a/common/mpls.h
+++ b/common/mpls.h
@@ -51,7 +51,6 @@ public:
     };
 
     MplsProtocol(StreamBase *stream, AbstractProtocol *parent = 0);
-    virtual ~MplsProtocol();
 
     static AbstractProtocol* createInstance(StreamBase *stream,
         AbstractProtocol *parent = 0);
@@ -72,9 +71,6 @@ public:
                int streamIndex = 0) const;
     virtual bool setFieldData(int index, const QVariant &value, 
             FieldAttrib attrib = FieldValue);
-
-
-    virtual int protocolFrameVariableCount() const;
 
 private:
     OstProto::Mpls    data;

--- a/common/mpls.proto
+++ b/common/mpls.proto
@@ -28,8 +28,6 @@ message Mpls {
     optional uint32 exp   = 2;
     optional bool   bos   = 3;
     optional uint32 ttl   = 4 [default = 255];
-
-    optional bool is_override_bos = 5 [default = false];
 }
 
 extend Protocol {

--- a/common/mpls.proto
+++ b/common/mpls.proto
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2010 Srivats P.
+Copyright (C) 2015 Ilya Volchanetskiy
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+import "protocol.proto";
+
+package OstProto;
+
+// MPLS Protocol
+message Mpls {
+    optional uint32 label = 1;
+    optional uint32 exp   = 2;
+    optional bool   bos   = 3;
+    optional uint32 ttl   = 4 [default = 255];
+
+    optional bool is_override_bos = 5 [default = false];
+}
+
+extend Protocol {
+    optional Mpls mpls = 209;
+}

--- a/common/mpls.ui
+++ b/common/mpls.ui
@@ -89,19 +89,6 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_27">
-     <property name="text">
-      <string>TTL</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="buddy">
-      <cstring>mplsTtl</cstring>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="1">
     <widget class="QLineEdit" name="mplsTtl">
      <property name="enabled">
@@ -128,10 +115,29 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="mplsOverrideBos">
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_27">
      <property name="text">
-      <string>Override Bottom of Stack</string>
+      <string>TTL</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>mplsTtl</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_28">
+     <property name="text">
+      <string>Bottom of Stack</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>mplsTtl</cstring>
      </property>
     </widget>
    </item>
@@ -143,22 +149,5 @@
   <tabstop>mplsTtl</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>mplsOverrideBos</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mplsBos</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>109</x>
-     <y>153</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>290</x>
-     <y>154</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/common/mpls.ui
+++ b/common/mpls.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Mpls</class>
+ <widget class="QWidget" name="Mpls">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>553</width>
+    <height>183</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_22">
+     <property name="text">
+      <string>Label</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>mplsLabel</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="mplsLabel">
+     <property name="inputMask">
+      <string/>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="maxLength">
+      <number>7</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_24">
+     <property name="text">
+      <string>Traffic class</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>mplsExp</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="mplsExp">
+     <property name="inputMask">
+      <string/>
+     </property>
+     <property name="maxLength">
+      <number>1</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="2">
+    <spacer>
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_27">
+     <property name="text">
+      <string>TTL</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="buddy">
+      <cstring>mplsTtl</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="mplsTtl">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="maxLength">
+      <number>3</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLineEdit" name="mplsBos">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="maxLength">
+      <number>1</number>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="mplsOverrideBos">
+     <property name="text">
+      <string>Override Bottom of Stack</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>mplsLabel</tabstop>
+  <tabstop>mplsExp</tabstop>
+  <tabstop>mplsTtl</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>mplsOverrideBos</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mplsBos</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>109</x>
+     <y>153</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>290</x>
+     <y>154</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/common/mplsconfig.cpp
+++ b/common/mplsconfig.cpp
@@ -27,10 +27,6 @@ MplsConfigForm::MplsConfigForm(QWidget *parent)
     setupUi(this);
 }
 
-MplsConfigForm::~MplsConfigForm()
-{
-}
-
 MplsConfigForm* MplsConfigForm::createInstance()
 {
     return new MplsConfigForm;

--- a/common/mplsconfig.cpp
+++ b/common/mplsconfig.cpp
@@ -54,11 +54,6 @@ void MplsConfigForm::loadWidget(AbstractProtocol *proto)
             MplsProtocol::mpls_bos,
             AbstractProtocol::FieldValue
         ).toString());
-    mplsOverrideBos->setChecked(
-        proto->fieldData(
-            MplsProtocol::mpls_is_override_bos,
-            AbstractProtocol::FieldValue
-        ).toBool());
 }
 
 void MplsConfigForm::storeWidget(AbstractProtocol *proto)
@@ -75,7 +70,4 @@ void MplsConfigForm::storeWidget(AbstractProtocol *proto)
     proto->setFieldData(
         MplsProtocol::mpls_bos,
         mplsBos->text());
-    proto->setFieldData(
-        MplsProtocol::mpls_is_override_bos,
-        mplsOverrideBos->isChecked());
 }

--- a/common/mplsconfig.cpp
+++ b/common/mplsconfig.cpp
@@ -1,0 +1,85 @@
+/*
+Copyright (C) 2010, 2014 Srivats P.
+Copyright (C) 2015 Ilya Volchanetskiy
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#include "mplsconfig.h"
+#include "mpls.h"
+
+MplsConfigForm::MplsConfigForm(QWidget *parent)
+    : AbstractProtocolConfigForm(parent)
+{
+    setupUi(this);
+}
+
+MplsConfigForm::~MplsConfigForm()
+{
+}
+
+MplsConfigForm* MplsConfigForm::createInstance()
+{
+    return new MplsConfigForm;
+}
+
+void MplsConfigForm::loadWidget(AbstractProtocol *proto)
+{
+    mplsLabel->setText(
+        proto->fieldData(
+            MplsProtocol::mpls_label,
+            AbstractProtocol::FieldValue
+        ).toString());
+    mplsExp->setText(
+        proto->fieldData(
+            MplsProtocol::mpls_exp,
+            AbstractProtocol::FieldValue
+        ).toString());
+    mplsTtl->setText(
+        proto->fieldData(
+            MplsProtocol::mpls_ttl,
+            AbstractProtocol::FieldValue
+        ).toString());
+    mplsBos->setText(
+        proto->fieldData(
+            MplsProtocol::mpls_bos,
+            AbstractProtocol::FieldValue
+        ).toString());
+    mplsOverrideBos->setChecked(
+        proto->fieldData(
+            MplsProtocol::mpls_is_override_bos,
+            AbstractProtocol::FieldValue
+        ).toBool());
+}
+
+void MplsConfigForm::storeWidget(AbstractProtocol *proto)
+{
+    proto->setFieldData(
+        MplsProtocol::mpls_label,
+        mplsLabel->text());
+    proto->setFieldData(
+        MplsProtocol::mpls_exp,
+        mplsExp->text());
+    proto->setFieldData(
+        MplsProtocol::mpls_ttl,
+        mplsTtl->text());
+    proto->setFieldData(
+        MplsProtocol::mpls_bos,
+        mplsBos->text());
+    proto->setFieldData(
+        MplsProtocol::mpls_is_override_bos,
+        mplsOverrideBos->isChecked());
+}

--- a/common/mplsconfig.h
+++ b/common/mplsconfig.h
@@ -1,0 +1,44 @@
+/*
+Copyright (C) 2010, 2014 Srivats P.
+Copyright (C) 2015 Ilya Volchanetskiy
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#ifndef _MPLS_CONFIG_H
+#define _MPLS_CONFIG_H
+
+#include "abstractprotocolconfig.h"
+#include "ui_mpls.h"
+
+class MplsConfigForm :
+    public AbstractProtocolConfigForm, 
+    private Ui::Mpls
+{
+    Q_OBJECT
+public:
+    MplsConfigForm(QWidget *parent = 0);
+    virtual ~MplsConfigForm();
+
+    static MplsConfigForm* createInstance();
+
+    virtual void loadWidget(AbstractProtocol *proto);
+    virtual void storeWidget(AbstractProtocol *proto);
+
+private slots:
+};
+
+#endif

--- a/common/mplsconfig.h
+++ b/common/mplsconfig.h
@@ -31,7 +31,6 @@ class MplsConfigForm :
     Q_OBJECT
 public:
     MplsConfigForm(QWidget *parent = 0);
-    virtual ~MplsConfigForm();
 
     static MplsConfigForm* createInstance();
 

--- a/common/mplspdml.cpp
+++ b/common/mplspdml.cpp
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 2014 Srivats P.
+Copyright (C) 2015 Ilya Volchanetskiy
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#include "mplspdml.h"
+
+#include "mpls.pb.h"
+
+PdmlMplsProtocol::PdmlMplsProtocol()
+{
+    ostProtoId_ = OstProto::Protocol::kMplsFieldNumber;
+
+    fieldMap_.insert("mpls.label", OstProto::Mpls::kLabelFieldNumber);
+    fieldMap_.insert("mpls.exp", OstProto::Mpls::kExpFieldNumber);
+    fieldMap_.insert("mpls.bottom", OstProto::Mpls::kBosFieldNumber);
+    fieldMap_.insert("mpls.ttl", OstProto::Mpls::kTtlFieldNumber);
+}
+
+PdmlMplsProtocol::~PdmlMplsProtocol()
+{
+}
+
+PdmlProtocol* PdmlMplsProtocol::createInstance()
+{
+    return new PdmlMplsProtocol();
+}

--- a/common/mplspdml.h
+++ b/common/mplspdml.h
@@ -1,0 +1,37 @@
+/*
+Copyright (C) 2014 Srivats P.
+Copyright (C) 2015 Ilya Volchanetskiy
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#ifndef _MPLS_PDML_H
+#define _MPLS_PDML_H
+
+#include "pdmlprotocol.h"
+
+class PdmlMplsProtocol : public PdmlProtocol
+{
+public:
+    virtual ~PdmlMplsProtocol();
+
+    static PdmlProtocol* createInstance();
+
+protected:
+    PdmlMplsProtocol();
+};
+
+#endif

--- a/common/ostproto.pro
+++ b/common/ostproto.pro
@@ -18,6 +18,7 @@ PROTOS = \
     vlan.proto \
     svlan.proto \
     vlanstack.proto \
+    mpls.proto \
     arp.proto \
     ip4.proto \
     ip6.proto \
@@ -55,6 +56,7 @@ HEADERS += \
     dot2llc.h \
     snap.h \
     dot2snap.h \
+    mpls.h \
     arp.h \
     ip4.h \
     ip6.h \
@@ -90,6 +92,7 @@ SOURCES += \
     dot3.cpp \
     llc.cpp \
     snap.cpp \
+    mpls.cpp \
     arp.cpp \
     ip4.cpp \
     ip6.cpp \

--- a/common/ostprotogui.pro
+++ b/common/ostprotogui.pro
@@ -15,6 +15,7 @@ FORMS += \
     dot3.ui \
     llc.ui \
     snap.ui \
+    mpls.ui \
     arp.ui \
     ip4.ui \
     ip6.ui \
@@ -59,6 +60,7 @@ HEADERS += \
     dot2llcconfig.h \
     snapconfig.h \
     dot2snapconfig.h \
+    mplsconfig.h \
     arpconfig.h \
     ip4config.h \
     ip6config.h \
@@ -94,6 +96,7 @@ SOURCES += \
     dot3config.cpp \
     llcconfig.cpp \
     snapconfig.cpp \
+    mplsconfig.cpp \
     arpconfig.cpp \
     ip4config.cpp \
     ip6config.cpp \
@@ -114,6 +117,7 @@ SOURCES += \
     svlanpdml.cpp \
     eth2pdml.cpp \
     llcpdml.cpp \
+    mplspdml.cpp \
     arppdml.cpp \
     ip4pdml.cpp \
     ip6pdml.cpp \

--- a/common/pdmlreader.cpp
+++ b/common/pdmlreader.cpp
@@ -40,6 +40,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "textprotopdml.h"
 #include "udppdml.h"
 #include "vlanpdml.h"
+#include "mplspdml.h"
 
 PdmlReader::PdmlReader(OstProto::StreamConfigList *streams)
 {
@@ -77,6 +78,7 @@ PdmlReader::PdmlReader(OstProto::StreamConfigList *streams)
     factory_.insert("udp", PdmlUdpProtocol::createInstance);
     factory_.insert("udplite", PdmlUdpProtocol::createInstance);
     factory_.insert("vlan", PdmlVlanProtocol::createInstance);
+    factory_.insert("mpls", PdmlMplsProtocol::createInstance);
 }
 
 PdmlReader::~PdmlReader()

--- a/common/protocol.proto
+++ b/common/protocol.proto
@@ -140,6 +140,7 @@ message Protocol {
         kDot2LlcFieldNumber = 206;
         kDot2SnapFieldNumber = 207;
         kVlanStackFieldNumber = 208;
+        kMplsFieldNumber = 209;
 
         kArpFieldNumber = 300;
         kIp4FieldNumber = 301;

--- a/common/protocolmanager.cpp
+++ b/common/protocolmanager.cpp
@@ -26,6 +26,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "vlan.h"
 #include "svlan.h"
 #include "vlanstack.h"
+#include "mpls.h"
 
 // L2 Protos
 #include "dot3.h"    
@@ -76,6 +77,8 @@ ProtocolManager::ProtocolManager()
             (void*) SVlanProtocol::createInstance);
     registerProtocol(OstProto::Protocol::kVlanStackFieldNumber,
             (void*) VlanStackProtocol::createInstance);
+    registerProtocol(OstProto::Protocol::kMplsFieldNumber,
+            (void*) MplsProtocol::createInstance);
 
     registerProtocol(OstProto::Protocol::kEth2FieldNumber,
             (void*) Eth2Protocol::createInstance);

--- a/common/protocolwidgetfactory.cpp
+++ b/common/protocolwidgetfactory.cpp
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "vlanconfig.h"
 #include "svlanconfig.h"
 #include "vlanstackconfig.h"
+#include "mplsconfig.h"
 // L2 Protocol Widgets
 #include "eth2config.h"
 #include "dot3config.h"
@@ -74,6 +75,9 @@ ProtocolWidgetFactory::ProtocolWidgetFactory()
     OstProtocolWidgetFactory->registerProtocolConfigWidget(
             OstProto::Protocol::kVlanStackFieldNumber, 
             (void*) VlanStackConfigForm::createInstance);
+    OstProtocolWidgetFactory->registerProtocolConfigWidget(
+            OstProto::Protocol::kMplsFieldNumber,
+            (void*) MplsConfigForm::createInstance);
 
     OstProtocolWidgetFactory->registerProtocolConfigWidget(
             OstProto::Protocol::kEth2FieldNumber, 


### PR DESCRIPTION
First of all, thank you for this great piece of software.
I tried to add MPLS support to Ostinato. I'm not experienced, so I probably did some things wrong.
And here are the things I'm not sure about:
- I didn't know where to place MPLS in `protocol.proto`, `ostproto.pro` and `ostprotogui.pro` files
- MPLS is only available under Advanced "tab"
- It looks like EXP field has been renamed to "Traffic Class" but it's still called "EXP" in Wireshark and PDML. I used "exp" everywhere except for UI.
- There are two EtherType values for MPLS: `0x8847` and `0x8848` "for unicast and multicast connections respectively", but I set the first one as `protocolId`, one would have to set EtherType manually to use multicast
