### PR TITLE
fixed the testcases in rpctest.py

### DIFF
--- a/test/rpctest.py
+++ b/test/rpctest.py
@@ -8,6 +8,7 @@ import sys
 import time
 
 sys.path.insert(1, '../binding')
+import core
 from core import ost_pb, DroneProxy
 from rpc import RpcError
 from protocols.mac_pb2 import mac
@@ -115,7 +116,7 @@ try:
     passed = False
     suite.test_begin('connectFailsForIncompatibleVersion')
     try:
-        drone.proxy_version = '0.1.1'
+        core.__version__ = '0.1.1'
         drone.connect()
     except RpcError as e:
         if ('needs client version' in str(e)):
@@ -124,7 +125,7 @@ try:
         else:
             raise
     finally:
-        drone.proxy_version = None
+        core.__version__ = None
         suite.test_end(passed)
 
     # ----------------------------------------------------------------- #
@@ -133,7 +134,7 @@ try:
     passed = False
     suite.test_begin('checkVersionFailsForInvalidClientVersion')
     try:
-        drone.proxy_version = '0-1-1'
+        core.__version__ = '0-1-1'
         drone.connect()
     except RpcError as e:
         if ('invalid version' in str(e)):
@@ -141,7 +142,7 @@ try:
         else:
             raise
     finally:
-        drone.proxy_version = None
+        core.__version__ = None
         suite.test_end(passed)
 
     # ----------------------------------------------------------------- #
@@ -153,7 +154,7 @@ try:
     passed = False
     suite.test_begin('checkVersionReturnsIncompatForDifferentMajorVersion')
     try:
-        drone.proxy_version = (str(int(drone_version[0])+1)
+        core.__version__ = (str(int(drone_version[0])+1)
                                 + '.' + drone_version[1])
         drone.connect()
     except RpcError as e:
@@ -163,7 +164,7 @@ try:
         else:
             raise
     finally:
-        drone.proxy_version = None
+        core.__version__ = None
         suite.test_end(passed)
 
     # ----------------------------------------------------------------- #
@@ -175,7 +176,7 @@ try:
     passed = False
     suite.test_begin('checkVersionReturnsIncompatForDifferentMinorVersion')
     try:
-        drone.proxy_version = (drone_version[0]
+        core.__version__ = (drone_version[0]
                                 + '.' + str(int(drone_version[1])+1))
         drone.connect()
     except RpcError as e:
@@ -185,7 +186,7 @@ try:
         else:
             raise
     finally:
-        drone.proxy_version = None
+        core.__version__ = None
         suite.test_end(passed)
 
     # ----------------------------------------------------------------- #
@@ -196,7 +197,7 @@ try:
     passed = False
     suite.test_begin('checkVersionReturnsCompatForDifferentRevisionVersion')
     try:
-        drone.proxy_version = (drone_version[0]
+        core.__version__ = (drone_version[0]
                                 + '.' + drone_version[1]
                                 + '.' + '999')
         drone.connect()
@@ -204,7 +205,7 @@ try:
     except RpcError as e:
         raise
     finally:
-        drone.proxy_version = None
+        core.__versrion__ = None
         suite.test_end(passed)
 
     # ----------------------------------------------------------------- #
@@ -298,25 +299,26 @@ try:
     # TESTCASE: Verify a RPC with missing required fields in request fails
     #           and subsequently passes when the fields are initialized
     # ----------------------------------------------------------------- #
-#    passed = False
-#    suite.test_begin('rpcWithMissingRequiredFieldsFails')
-#    pid = ost_pb.PortId()
-#    try:
-#        sid_list = drone.getStreamIdList(pid)
-#    except RpcError as e:
-#        if ('missing required fields in request' in str(e)):
-#            passed = True
-#        else:
-#            raise
-#
-#    try:
-#        pid.id = tx_port_number
-#        sid_list = drone.getStreamIdList(pid)
-#    except RpcError as e:
-#        passed = False
-#        raise
-#    finally:
-#        suite.test_end(passed)
+    passed = False
+    suite.test_begin('rpcWithMissingRequiredFieldsFails')
+    pid = ost_pb.PortId()
+    try:
+        drone.getStreamIdList(pid)
+    except:
+        e = sys.exc_info()[0]
+        if ('EncodeError' in str(e)):
+            passed = True
+            log.info("Retrying RPC after adding the missing fields")
+            pid.id = tx_port_number
+            try:
+                sid_list = drone.getStreamIdList(pid)
+            except:
+                passed = False
+                raise
+        else:
+            raise
+    finally:
+        suite.test_end(passed)
 
     # ----------------------------------------------------------------- #
     # TESTCASE: Verify invoking addStream() during transmit fails
@@ -379,7 +381,6 @@ try:
         drone.stopTransmit(tx_port)
         suite.test_end(passed)
 
-
     # ----------------------------------------------------------------- #
     # TESTCASE: Verify invoking startTransmit() during transmit is a NOP, 
     #           not a restart
@@ -416,7 +417,6 @@ try:
     finally:
         drone.stopTransmit(tx_port)
         suite.test_end(passed)
-
 
     # ----------------------------------------------------------------- #
     # TESTCASE: Verify invoking startCapture() during capture is a NOP, 


### PR DESCRIPTION
fixed the testcases in rpctest.py

Test report, with the changes:
===========================================================
TEST REPORT
===========================================================
anyRpcBeforeCheckVersionFails: 1
connectFailsForIncompatibleVersion: 1
checkVersionFailsForInvalidClientVersion: 1
checkVersionReturnsIncompatForDifferentMajorVersion: 1
checkVersionReturnsIncompatForDifferentMinorVersion: 1
checkVersionReturnsCompatForDifferentRevisionVersion: 1
rpcWithMissingRequiredFieldsFails: 1
addStreamDuringTransmitFails: 1
modifyStreamDuringTransmitFails: 1
deleteStreamDuringTransmitFails: 1
startTransmitDuringTransmitIsNopNotRestart: 1
startCaptureDuringTransmitIsNopNotRestart: 1
stopTransmitWhenTransmitNotRunningIsNop: 1
stopCaptureWhenCaptureNotRunningIsNop: 1
startStopTransmitCaptureOrderCapturesAllPackets: 1
Passed: 15/15
Completed: 1
