### PR TITLE
make python-ostinato python3 compliant (work in progress)

### DIFF
--- a/binding/core.py
+++ b/binding/core.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from builtins import object
 # Copyright (C) 2014 Srivats P.
 #
 # This file is part of "Ostinato"

--- a/binding/core.py
+++ b/binding/core.py
@@ -1,24 +1,25 @@
+from __future__ import absolute_import
 # Copyright (C) 2014 Srivats P.
-# 
+#
 # This file is part of "Ostinato"
-# 
+#
 # This is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 import os
-from rpc import OstinatoRpcChannel, OstinatoRpcController, RpcError
-import protocols.protocol_pb2 as ost_pb
-from __init__ import __version__
+from .rpc import OstinatoRpcChannel, OstinatoRpcController, RpcError
+from .protocols import protocol_pb2 as ost_pb
+from .__init__ import __version__
 
 class DroneProxy(object):
 
@@ -47,7 +48,7 @@ class DroneProxy(object):
         ver.version = __version__
         compat = self.checkVersion(ver)
         if compat.result == ost_pb.VersionCompatibility.kIncompatible:
-            raise RpcError('incompatible version %s (%s)' % 
+            raise RpcError('incompatible version %s (%s)' %
                     (ver.version, compat.notes))
 
     def disconnect(self):

--- a/binding/example.py
+++ b/binding/example.py
@@ -1,17 +1,19 @@
 #! /usr/bin/env python
 
 # standard modules
+from __future__ import print_function
+from __future__ import absolute_import
 import logging
 import os
 import sys
 import time
 
-# ostinato modules 
+# ostinato modules
 # (user scripts using the installed package should prepend ostinato. i.e
 #  ostinato.core and ostinato.protocols)
-from core import ost_pb, DroneProxy
-from protocols.mac_pb2 import mac
-from protocols.ip4_pb2 import ip4, Ip4
+from .core import ost_pb, DroneProxy
+from .protocols.mac_pb2 import mac
+from .protocols.ip4_pb2 import ip4, Ip4
 
 # initialize defaults
 use_defaults = False
@@ -58,7 +60,7 @@ drone = DroneProxy(host_name)
 
 try:
     # connect to drone
-    log.info('connecting to drone(%s:%d)' 
+    log.info('connecting to drone(%s:%d)'
             % (drone.hostName(), drone.portNumber()))
     drone.connect()
 
@@ -74,12 +76,12 @@ try:
         log.warning('drone has no ports!')
         sys.exit(1)
 
-    # print port list and get tx/rx port id 
+    # print port list and get tx/rx port id
     print('Port List')
     print('---------')
     for port in port_config_list.port:
         print('%d.%s (%s)' % (port.port_id.id, port.name, port.description))
-        # use a loopback port as default tx/rx port 
+        # use a loopback port as default tx/rx port
         if ('lo' in port.name or 'loopback' in port.description.lower()):
             tx_port_number = port.port_id.id
             rx_port_number = port.port_id.id
@@ -165,7 +167,7 @@ try:
 
     #log.info('--> (tx_stats)' + tx_stats.__str__())
     #log.info('--> (rx_stats)' + rx_stats.__str__())
-    log.info('tx pkts = %d, rx pkts = %d' % 
+    log.info('tx pkts = %d, rx pkts = %d' %
             (tx_stats.port_stats[0].tx_pkts, rx_stats.port_stats[0].rx_pkts))
 
     # retrieve and dump received packets

--- a/binding/example.py
+++ b/binding/example.py
@@ -3,6 +3,7 @@
 # standard modules
 from __future__ import print_function
 from __future__ import absolute_import
+from builtins import input
 import logging
 import os
 import sys
@@ -53,7 +54,7 @@ print('port as both Tx and Rx ports')
 print('')
 
 if not use_defaults:
-    s = raw_input('Drone\'s Hostname/IP [%s]: ' % (host_name))
+    s = input('Drone\'s Hostname/IP [%s]: ' % (host_name))
     host_name = s or host_name
 
 drone = DroneProxy(host_name)
@@ -87,11 +88,11 @@ try:
             rx_port_number = port.port_id.id
 
     if not use_defaults:
-        p = raw_input('Tx Port Id [%d]: ' % (tx_port_number))
+        p = input('Tx Port Id [%d]: ' % (tx_port_number))
         if p:
             tx_port_number = int(p)
 
-        p = raw_input('Rx Port Id [%d]: ' % (rx_port_number))
+        p = input('Rx Port Id [%d]: ' % (rx_port_number))
         if p:
             rx_port_number = int(p)
 

--- a/binding/rpc.py
+++ b/binding/rpc.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import str
 # Copyright (C) 2014 Srivats P.
 #
 # This file is part of "Ostinato"
@@ -123,7 +124,7 @@ class OstinatoRpcChannel(RpcChannel):
             elif msg_type == MSG_TYPE_BLOB:
                 response = resp
             elif msg_type == MSG_TYPE_ERROR:
-                raise RpcError(unicode(resp, 'utf-8'))
+                raise RpcError(str(resp, 'utf-8'))
             else:
                 raise RpcError('unknown RPC msg type %d' % msg_type)
 

--- a/binding/rpc.py
+++ b/binding/rpc.py
@@ -1,17 +1,18 @@
+from __future__ import print_function
 # Copyright (C) 2014 Srivats P.
-# 
+#
 # This file is part of "Ostinato"
-# 
+#
 # This is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
@@ -21,7 +22,7 @@ from google.protobuf.service import RpcController
 import logging
 import socket
 import struct
-import sys
+
 
 class PeerClosedConnError(Exception):
     def __init__(self, msg):
@@ -78,7 +79,7 @@ class OstinatoRpcChannel(RpcChannel):
 
         error = ''
         try:
-            self.log.info('invoking RPC %s(%s): %s', method.name, 
+            self.log.info('invoking RPC %s(%s): %s', method.name,
                     type(request).__name__, response_class.__name__)
             if not request.IsInitialized():
                 raise RpcError('missing required fields in request')
@@ -112,7 +113,7 @@ class OstinatoRpcChannel(RpcChannel):
 
             # verify response method is same as the one requested
             if method_index != method.index:
-                raise RpcMismatchError('RPC mismatch', 
+                raise RpcMismatchError('RPC mismatch',
                         expected = method.index, received = method_index)
 
             if msg_type == MSG_TYPE_RESPONSE:

--- a/binding/setup.py
+++ b/binding/setup.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 # Copyright (C) 2014 Srivats P.
-# 
+#
 # This file is part of "Ostinato"
-# 
+#
 # This is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-# 
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
+from __future__ import print_function
 import json
 import os
 import shutil


### PR DESCRIPTION
I'm hitting several issues here:
- protobuf 2.6.1 seems not to work with python 3.5: https://github.com/google/protobuf/issues/1276
- protobuf 3.0.0.b2 fixes the previous issue, but the generated code has buggy import statements. I can fix them manually but I'll first wait for protobuf developers to comment on the issue: https://github.com/google/protobuf/issues/1491
