### PR TITLE
Specify proto2 syntax in proto files.

### DIFF
--- a/common/arp.proto
+++ b/common/arp.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/dot2llc.proto
+++ b/common/dot2llc.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 import "dot3.proto";
 import "llc.proto";

--- a/common/dot2snap.proto
+++ b/common/dot2snap.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/dot3.proto
+++ b/common/dot3.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/emulproto.proto
+++ b/common/emulproto.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstEmul;

--- a/common/eth2.proto
+++ b/common/eth2.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/fileformat.proto
+++ b/common/fileformat.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/gmp.proto
+++ b/common/gmp.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/hexdump.proto
+++ b/common/hexdump.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/icmp.proto
+++ b/common/icmp.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/igmp.proto
+++ b/common/igmp.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 import "gmp.proto";
 

--- a/common/ip4.proto
+++ b/common/ip4.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/ip4over4.proto
+++ b/common/ip4over4.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 import "ip4.proto";
 

--- a/common/ip4over6.proto
+++ b/common/ip4over6.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/ip6.proto
+++ b/common/ip6.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/ip6over4.proto
+++ b/common/ip6over4.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/ip6over6.proto
+++ b/common/ip6over6.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 import "ip6.proto";
 

--- a/common/llc.proto
+++ b/common/llc.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/mac.proto
+++ b/common/mac.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/mld.proto
+++ b/common/mld.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 import "gmp.proto";
 

--- a/common/payload.proto
+++ b/common/payload.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/protocol.proto
+++ b/common/protocol.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 package OstProto;
 option cc_generic_services = true;
 option py_generic_services = true;

--- a/common/sample.proto
+++ b/common/sample.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/snap.proto
+++ b/common/snap.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/stp.proto
+++ b/common/stp.proto
@@ -19,6 +19,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 This module is developed by PLVision  <developers@plvision.eu>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/svlan.proto
+++ b/common/svlan.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 import "vlan.proto";
 

--- a/common/tcp.proto
+++ b/common/tcp.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/textproto.proto
+++ b/common/textproto.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/udp.proto
+++ b/common/udp.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/userscript.proto
+++ b/common/userscript.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/vlan.proto
+++ b/common/vlan.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;

--- a/common/vlanstack.proto
+++ b/common/vlanstack.proto
@@ -17,6 +17,8 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
+syntax = "proto2";
+
 import "protocol.proto";
 
 package OstProto;


### PR DESCRIPTION
Fixes warnings with protobuf 3.0.0:
```
[libprotobuf WARNING google/protobuf/compiler/parser.cc:547] No syntax specified for the proto file: <file>.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)
```
Closes: #193