### PR TITLE
Fix minor stream UI issues

### DIFF
--- a/client/dumpview.h
+++ b/client/dumpview.h
@@ -48,7 +48,7 @@ private:
     void populateDump(QByteArray &dump, int &selOfs, int &selSize, 
             QModelIndex parent = QModelIndex());
     bool inline isPrintable(char c) 
-        {if ((c > 48) && (c < 126)) return true; else return false; }
+        {if ((c >= 32) && (c <= 126)) return true; else return false; }
 
 private:
     QRect        mOffsetPaneTopRect;

--- a/common/mac.cpp
+++ b/common/mac.cpp
@@ -143,7 +143,7 @@ QVariant MacProtocol::fieldData(int index, FieldAttrib attrib,
             switch(attrib)
             {
                 case FieldName:            
-                    return QString("Desination");
+                    return QString("Destination");
                 case FieldValue:
                     return dstMac;
                 case FieldTextValue:


### PR DESCRIPTION
Fixed spelling of destination in MAC variable fields.

For the Stream Packet View, made matches inclusive and increased range to match more printable characters. This better matches the Hex Dump payload view, which displays 32 (0x20) to 126 (0x7D).

Fixes for issue #207