### PR TITLE
Update .travis.yml to reflect qt->qt@4 change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       compiler: gcc
 
 before_install:
-  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew update && brew tap cartr/qt4 && brew tap-pin cartr/qt4 && brew install qt && brew install protobuf && ls -lR /usr/local/include; fi"
+  - "if [ $TRAVIS_OS_NAME = 'osx' ]; then brew update && brew tap cartr/qt4 && brew tap-pin cartr/qt4 && brew install qt@4 && brew install protobuf && ls -lR /usr/local/include; fi"
 
 addons:
   apt:


### PR DESCRIPTION
At the request of Homebrew maintainers, my Qt 4 package is now called `qt@4`. This PR updates your .travis.yml file to reflect the name change.