### PR TITLE
Add missing include cmath in port.cpp

### DIFF
--- a/client/port.cpp
+++ b/client/port.cpp
@@ -28,6 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include <QVariant>
 #include <google/protobuf/descriptor.h>
 #include <vector>
+#include <cmath>
 
 extern QMainWindow *mainWindow;
 


### PR DESCRIPTION
While attempting to build HEAD on CentOS 8.1 I encountered the following error:

```
port.cpp: In member function ‘void Port::setAveragePacketRate(double)’:
port.cpp:192:18: error: ‘isnan’ is not a member of ‘std’
         if (std::isnan(rate))
                  ^~~~~
port.cpp: In member function ‘void Port::setAverageBitRate(double)’:
port.cpp:271:18: error: ‘isnan’ is not a member of ‘std’
         if (std::isnan(rate))
                  ^~~~~
```

Adding `#include <cmath>` to client/port.cpp allowed ostinato to compile successfully.