### PR TITLE
Improve UI/UX of configured traffic rate on a port

### DIFF
--- a/client/ostinato.pro
+++ b/client/ostinato.pro
@@ -65,6 +65,7 @@ HEADERS += \
     streamstatsfiltermodel.h \
     streamstatsmodel.h \
     streamstatswindow.h \
+    streamswidget.h \
     variablefieldswidget.h \
     xtableview.h
 
@@ -116,6 +117,7 @@ SOURCES += \
     streammodel.cpp \
     streamstatsmodel.cpp \
     streamstatswindow.cpp \
+    streamswidget.cpp \
     variablefieldswidget.cpp
 
 

--- a/client/ostinato.pro
+++ b/client/ostinato.pro
@@ -81,6 +81,7 @@ FORMS += \
     preferences.ui \
     streamconfigdialog.ui \
     streamstatswindow.ui \
+    streamswidget.ui \
     variablefieldswidget.ui
 
 SOURCES += \

--- a/client/ostinato.pro
+++ b/client/ostinato.pro
@@ -57,6 +57,7 @@ HEADERS += \
     portstatsproxymodel.h \
     portstatswindow.h \
     portswindow.h \
+    portwidget.h \
     preferences.h \
     settings.h \
     streamconfigdialog.h \
@@ -79,6 +80,7 @@ FORMS += \
     portstatsfilter.ui \
     portstatswindow.ui \
     portswindow.ui \
+    portwidget.ui \
     preferences.ui \
     streamconfigdialog.ui \
     streamstatswindow.ui \
@@ -111,6 +113,7 @@ SOURCES += \
     portstatsfilterdialog.cpp \
     portstatswindow.cpp \
     portswindow.cpp \
+    portwidget.cpp \
     preferences.cpp \
     streamconfigdialog.cpp \
     streamlistdelegate.cpp \

--- a/client/port.cpp
+++ b/client/port.cpp
@@ -317,6 +317,12 @@ void Port::setAverageBitRate(double bitsPerSec)
     emit portRateChanged(mPortGroupId, mPortId);
 }
 
+void Port::setAverageLoadRate(double load)
+{
+    Q_ASSERT(d.speed() > 0);
+    setAverageBitRate(load*d.speed()*1e6);
+}
+
 bool Port::newStreamAt(int index, OstProto::Stream const *stream)
 {
     Stream    *s = new Stream;

--- a/client/port.h
+++ b/client/port.h
@@ -102,6 +102,10 @@ public:
         { return d.transmit_mode(); }
     bool trackStreamStats() const
         { return d.is_tracking_stream_stats(); }
+    double speed() const
+        { return d.speed(); }
+    double averageLoadRate() const
+        { return d.speed() ? avgBitsPerSec_/(d.speed()*1e6) : 0; }
     double averagePacketRate() const
         { return avgPacketsPerSec_; }
     double averageBitRate() const
@@ -183,6 +187,7 @@ public:
 
     void setAveragePacketRate(double packetsPerSec);
     void setAverageBitRate(double bitsPerSec);
+    void setAverageLoadRate(double loadPercent);
     // FIXME(MED): Bad Hack! port should not need an external trigger to
     // recalculate - refactor client side domain objects and model objects
     void recalculateAverageRates();

--- a/client/portswindow.cpp
+++ b/client/portswindow.cpp
@@ -20,51 +20,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "portswindow.h"
 
 #include "applymsg.h"
-#include "clipboardhelper.h"
 #include "deviceswidget.h"
-#include "portconfigdialog.h"
-#include "settings.h"
-#include "streamconfigdialog.h"
-#include "streamfileformat.h"
-#include "streamlistdelegate.h"
-
 #include "fileformat.pb.h"
+#include "portconfigdialog.h"
+#include "portgrouplist.h"
+#include "settings.h"
+#include "streamswidget.h"
 
-#include "xqlocale.h"
-
-#include <QFileInfo>
 #include <QInputDialog>
-#include <QItemSelectionModel>
 #include <QMainWindow>
 #include <QMessageBox>
+#include <QProgressDialog>
 #include <QSortFilterProxyModel>
 
-extern ClipboardHelper *clipboardHelper;
 extern QMainWindow *mainWindow;
 
 PortsWindow::PortsWindow(PortGroupList *pgl, QWidget *parent)
     : QWidget(parent), proxyPortModel(NULL)
 {
-    QAction *sep;
-
-    delegate = new StreamListDelegate;
     proxyPortModel = new QSortFilterProxyModel(this);
 
-    //slm = new StreamListModel();
-    //plm = new PortGroupList();
     plm = pgl;
 
-    Ui::PortsWindow::setupUi(this);
-    Ui::StreamsWidget::setupUi(streamsWidget);
+    setupUi(this);
     applyMsg_ = new ApplyMessage();
+    streamsWidget->setPortGroupList(plm);
     devicesWidget->setPortGroupList(plm);
 
     tvPortList->header()->hide();
-
-    tvStreamList->setItemDelegate(delegate);
-
-    tvStreamList->verticalHeader()->setDefaultSectionSize(
-            tvStreamList->verticalHeader()->minimumSectionSize());
 
     // Populate PortList Context Menu Actions
     tvPortList->addAction(actionNew_Port_Group);
@@ -75,40 +58,17 @@ PortsWindow::PortsWindow(PortGroupList *pgl, QWidget *parent)
     tvPortList->addAction(actionExclusive_Control);
     tvPortList->addAction(actionPort_Configuration);
 
-    // Populate StreamList Context Menu Actions
-    tvStreamList->addAction(actionNew_Stream);
-    tvStreamList->addAction(actionEdit_Stream);
-    tvStreamList->addAction(actionDuplicate_Stream);
-    tvStreamList->addAction(actionDelete_Stream);
-
-    QAction *sep2 = new QAction(this);
-    sep2->setSeparator(true);
-    tvStreamList->addAction(sep2);
-
-    tvStreamList->addAction(actionOpen_Streams);
-    tvStreamList->addAction(actionSave_Streams);
-
     // PortList, StreamList, DeviceWidget actions combined
     // make this window's actions
     addActions(tvPortList->actions());
-    sep = new QAction(this);
+    QAction *sep = new QAction(this);
     sep->setSeparator(true);
     addAction(sep);
-    addActions(tvStreamList->actions());
+    addActions(streamsWidget->actions());
     sep = new QAction(this);
     sep->setSeparator(true);
     addAction(sep);
     addActions(devicesWidget->actions());
-
-    // Add the clipboard actions to the context menu of streamList
-    // but not to PortsWindow's actions since they are already available
-    // in the global Edit Menu
-    sep = new QAction("Clipboard", this);
-    sep->setSeparator(true);
-    tvStreamList->insertAction(sep2, sep);
-    tvStreamList->insertActions(sep2, clipboardHelper->actions());
-
-    tvStreamList->setModel(plm->getStreamModel());
 
     // XXX: It would be ideal if we only needed to do the below to 
     // get the proxy model to do its magic. However, the QModelIndex
@@ -141,50 +101,18 @@ PortsWindow::PortsWindow(PortGroupList *pgl, QWidget *parent)
             const QModelIndex&)));
     connect(this,
             SIGNAL(currentPortChanged(const QModelIndex&, const QModelIndex&)),
+            streamsWidget, SLOT(setCurrentPortIndex(const QModelIndex&)));
+    connect(this,
+            SIGNAL(currentPortChanged(const QModelIndex&, const QModelIndex&)),
             devicesWidget, SLOT(setCurrentPortIndex(const QModelIndex&)));
-
-    connect(plm->getStreamModel(), SIGNAL(rowsInserted(QModelIndex, int, int)), 
-        SLOT(updateStreamViewActions()));
-    connect(plm->getStreamModel(), SIGNAL(rowsRemoved(QModelIndex, int, int)), 
-        SLOT(updateStreamViewActions()));
-
-    connect(tvStreamList->selectionModel(), 
-        SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), 
-        SLOT(updateStreamViewActions()));
-    connect(tvStreamList->selectionModel(), 
-        SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
-        SLOT(updateStreamViewActions()));
-
-    tvStreamList->resizeColumnToContents(StreamModel::StreamIcon);
-    tvStreamList->resizeColumnToContents(StreamModel::StreamStatus);
 
     // Initially we don't have any ports/streams/devices
     //  - so send signal triggers
     when_portView_currentChanged(QModelIndex(), QModelIndex());
-    updateStreamViewActions();
-
-    connect(plm->getStreamModel(), 
-        SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)), 
-        this, SLOT(streamModelDataChanged()));
-    connect(plm->getStreamModel(), 
-        SIGNAL(modelReset()), 
-        this, SLOT(streamModelDataChanged()));
-}
-
-void PortsWindow::streamModelDataChanged()
-{
-    QModelIndex current = tvPortList->currentIndex();
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    if (plm->isPort(current))
-        plm->port(current).recalculateAverageRates();
 }
 
 PortsWindow::~PortsWindow()
 {
-    delete delegate;
     delete proxyPortModel;
     delete applyMsg_;
 }
@@ -322,30 +250,6 @@ void PortsWindow::showMyReservedPortsOnly(bool enabled)
         proxyPortModel->setFilterRegExp(QRegExp(""));
 }
 
-void PortsWindow::on_tvStreamList_activated(const QModelIndex & index)
-{
-    if (!index.isValid())
-    {
-        qDebug("%s: invalid index", __FUNCTION__);
-        return;
-    }
-
-    qDebug("stream list activated\n");
-
-    Port &curPort = plm->port(proxyPortModel ?
-        proxyPortModel->mapToSource(tvPortList->currentIndex()) :
-        tvPortList->currentIndex());
-
-    QList<Stream*> streams;
-    streams.append(curPort.mutableStreamByIndex(index.row(), false));
-
-    StreamConfigDialog scd(streams, curPort, this);
-    if (scd.exec() == QDialog::Accepted) {
-        curPort.recalculateAverageRates();
-        curPort.setLocalConfigChanged(true);
-    }
-}
-
 void PortsWindow::when_portView_currentChanged(const QModelIndex& currentIndex,
     const QModelIndex& previousIndex)
 {
@@ -357,16 +261,12 @@ void PortsWindow::when_portView_currentChanged(const QModelIndex& currentIndex,
         previous = proxyPortModel->mapToSource(previous);
     }
 
-    plm->getStreamModel()->setCurrentPortIndex(current);
     updatePortViewActions(currentIndex);
-    updateStreamViewActions();
 
     qDebug("In %s", __FUNCTION__);
 
     if (previous.isValid() && plm->isPort(previous))
     {
-        disconnect(&(plm->port(previous)), SIGNAL(portRateChanged(int, int)),
-                this, SLOT(updatePortRates()));
         disconnect(&(plm->port(previous)),
                    SIGNAL(localConfigChanged(int, int, bool)),
                    this,
@@ -387,9 +287,6 @@ void PortsWindow::when_portView_currentChanged(const QModelIndex& currentIndex,
         else if (plm->isPort(current))
         {
             swDetail->setCurrentIndex(2);    // port detail page
-            updatePortRates();
-            connect(&(plm->port(current)), SIGNAL(portRateChanged(int, int)),
-                    SLOT(updatePortRates()));
             connect(&(plm->port(current)),
                     SIGNAL(localConfigChanged(int, int, bool)),
                     SLOT(updateApplyHint(int, int, bool)));
@@ -447,139 +344,6 @@ void PortsWindow::when_portModel_reset()
     when_portView_currentChanged(QModelIndex(), tvPortList->currentIndex());
 }
 
-void PortsWindow::on_startTx_clicked()
-{
-    QModelIndex current = tvPortList->currentIndex();
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    Q_ASSERT(plm->isPort(current));
-
-    QModelIndex curPortGroup = plm->getPortModel()->parent(current);
-    Q_ASSERT(curPortGroup.isValid());
-    Q_ASSERT(plm->isPortGroup(curPortGroup));
-
-    QList<uint> portList({plm->port(current).id()});
-    plm->portGroup(curPortGroup).startTx(&portList);
-}
-
-void PortsWindow::on_stopTx_clicked()
-{
-    QModelIndex current = tvPortList->currentIndex();
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    Q_ASSERT(plm->isPort(current));
-
-    QModelIndex curPortGroup = plm->getPortModel()->parent(current);
-    Q_ASSERT(curPortGroup.isValid());
-    Q_ASSERT(plm->isPortGroup(curPortGroup));
-
-    QList<uint> portList({plm->port(current).id()});
-    plm->portGroup(curPortGroup).stopTx(&portList);
-}
-
-void PortsWindow::on_averagePacketsPerSec_editingFinished()
-{
-    QModelIndex current = tvPortList->currentIndex();
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    Q_ASSERT(plm->isPort(current));
-
-    bool isOk;
-    double pps = XLocale().toDouble(averagePacketsPerSec->text(), &isOk);
-
-    plm->port(current).setAveragePacketRate(pps);
-}
-
-void PortsWindow::on_averageBitsPerSec_editingFinished()
-{
-    QModelIndex current = tvPortList->currentIndex();
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    Q_ASSERT(plm->isPort(current));
-
-    bool isOk;
-    double bps = XLocale().toDouble(averageBitsPerSec->text(), &isOk);
-
-    plm->port(current).setAverageBitRate(bps);
-}
-
-void PortsWindow::updatePortRates()
-{
-    QModelIndex current = tvPortList->currentIndex();
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    if (!current.isValid())
-        return;
-
-    if (!plm->isPort(current))
-        return;
-
-    averagePacketsPerSec->setText(QString("%L1")
-            .arg(plm->port(current).averagePacketRate(), 0, 'f', 4));
-    averageBitsPerSec->setText(QString("%L1")
-            .arg(plm->port(current).averageBitRate(), 0, 'f', 0));
-}
-
-void PortsWindow::updateStreamViewActions()
-{
-    QModelIndex current = tvPortList->currentIndex();
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    // For some reason hasSelection() returns true even if selection size is 0
-    // so additional check for size introduced
-    if (tvStreamList->selectionModel()->hasSelection() &&
-        (tvStreamList->selectionModel()->selection().size() > 0))
-    {
-        qDebug("Has selection %d",
-            tvStreamList->selectionModel()->selection().size());
-
-        // If more than one non-contiguous ranges selected,
-        // disable "New" and "Edit"
-        if (tvStreamList->selectionModel()->selection().size() > 1)
-        {
-            actionNew_Stream->setDisabled(true);
-            actionEdit_Stream->setDisabled(true);
-        }
-        else
-        {
-            actionNew_Stream->setEnabled(true);
-            actionEdit_Stream->setEnabled(true);
-        }
-
-        // Duplicate/Delete are always enabled as long as we have a selection
-        actionDuplicate_Stream->setEnabled(true);
-        actionDelete_Stream->setEnabled(true);
-    }
-    else
-    {
-        qDebug("No selection");
-        if (plm->isPort(current))
-            actionNew_Stream->setEnabled(true);
-        else
-            actionNew_Stream->setDisabled(true);
-        actionEdit_Stream->setDisabled(true);
-        actionDuplicate_Stream->setDisabled(true);
-        actionDelete_Stream->setDisabled(true);
-    }
-    actionOpen_Streams->setEnabled(plm->isPort(current));
-    actionSave_Streams->setEnabled(tvStreamList->model()->rowCount() > 0);
-
-    startTx->setEnabled(tvStreamList->model()->rowCount() > 0);
-    stopTx->setEnabled(tvStreamList->model()->rowCount() > 0);
-}
-
 void PortsWindow::updateApplyHint(int /*portGroupId*/, int /*portId*/,
         bool configChanged)
 {
@@ -587,7 +351,7 @@ void PortsWindow::updateApplyHint(int /*portGroupId*/, int /*portId*/,
         applyHint->setText("Configuration has changed - "
                            "<font color='red'><b>click Apply</b></font> "
                            "to activate the changes");
-    else if (tvStreamList->model()->rowCount() > 0)
+    else if (plm->getStreamModel()->rowCount() > 0)
         applyHint->setText("Configuration activated - "
                            "click <img src=':/icons/control_play'/> "
                            "to transmit packets");
@@ -839,259 +603,3 @@ void PortsWindow::on_actionPort_Configuration_triggered()
     if (dialog.exec() == QDialog::Accepted)
         plm->portGroup(current.parent()).modifyPort(current.row(), config);
 }
-
-void PortsWindow::on_actionNew_Stream_triggered()
-{
-    qDebug("New Stream Action");
-
-    QItemSelectionModel* selectionModel = tvStreamList->selectionModel();
-    if (selectionModel->selection().size() > 1) {
-        qDebug("%s: Unexpected selection size %d, can't add", __FUNCTION__,
-                selectionModel->selection().size());
-        return;
-    }
-
-    // In case nothing is selected, insert 1 row at the end
-    StreamModel *streamModel = plm->getStreamModel();
-    int row = streamModel->rowCount(), count = 1;
-
-    // In case we have a single range selected; insert as many rows as
-    // in the singe selected range before the top of the selected range
-    if (selectionModel->selection().size() == 1)
-    {
-        row = selectionModel->selection().at(0).top();
-        count = selectionModel->selection().at(0).height();
-    }
-
-    Port &curPort = plm->port(proxyPortModel ?
-        proxyPortModel->mapToSource(tvPortList->currentIndex()) :
-        tvPortList->currentIndex());
-
-    QList<Stream*> streams;
-    for (int i = 0; i < count; i++)
-        streams.append(new Stream);
-
-    StreamConfigDialog scd(streams, curPort, this);
-    scd.setWindowTitle(tr("Add Stream"));
-    if (scd.exec() == QDialog::Accepted)
-        streamModel->insert(row, streams);
-}
-
-void PortsWindow::on_actionEdit_Stream_triggered()
-{
-    qDebug("Edit Stream Action");
-
-    QItemSelectionModel* streamModel = tvStreamList->selectionModel();
-    if (!streamModel->hasSelection())
-        return;
-
-    Port &curPort = plm->port(proxyPortModel ?
-        proxyPortModel->mapToSource(tvPortList->currentIndex()) :
-        tvPortList->currentIndex());
-
-    QList<Stream*> streams;
-    foreach(QModelIndex index, streamModel->selectedRows())
-        streams.append(curPort.mutableStreamByIndex(index.row(), false));
-
-    StreamConfigDialog scd(streams, curPort, this);
-    if (scd.exec() == QDialog::Accepted) {
-        curPort.recalculateAverageRates();
-        curPort.setLocalConfigChanged(true);
-    }
-}
-
-void PortsWindow::on_actionDuplicate_Stream_triggered()
-{
-    QItemSelectionModel* model = tvStreamList->selectionModel();
-    QModelIndex current = tvPortList->selectionModel()->currentIndex();
-
-    qDebug("Duplicate Stream Action");
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    if (model->hasSelection())
-    {
-        bool isOk;
-        int count = QInputDialog::getInt(this, "Duplicate Streams",
-                "Count", 1, 1, 9999, 1, &isOk);
-
-        if (!isOk)
-            return;
-
-        QList<int> list;
-        foreach(QModelIndex index, model->selectedRows())
-            list.append(index.row());
-        plm->port(current).duplicateStreams(list, count);
-    }
-    else
-        qDebug("No selection");
-}
-
-void PortsWindow::on_actionDelete_Stream_triggered()
-{
-    qDebug("Delete Stream Action");
-
-    QModelIndex        index;
-
-    if (tvStreamList->selectionModel()->hasSelection())
-    {
-        qDebug("SelectedIndexes %d",
-            tvStreamList->selectionModel()->selectedRows().size());
-        while(tvStreamList->selectionModel()->selectedRows().size())
-        {
-            index = tvStreamList->selectionModel()->selectedRows().at(0);
-            plm->getStreamModel()->removeRows(index.row(), 1);    
-        }
-    }
-    else
-        qDebug("No selection");
-}
-
-void PortsWindow::on_actionOpen_Streams_triggered()
-{
-    qDebug("Open Streams Action");
-
-    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
-                                            StreamFileFormat::kOpenFile);
-    QString fileType;
-    QModelIndex current = tvPortList->selectionModel()->currentIndex();
-    static QString dirName;
-    QString fileName;
-    QString errorStr;
-    bool append = true;
-    bool ret;
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    Q_ASSERT(plm->isPort(current));
-
-    if (fileTypes.size())
-        fileType = fileTypes.at(0);
-
-    fileName = QFileDialog::getOpenFileName(this, tr("Open Streams"),
-            dirName, fileTypes.join(";;"), &fileType);
-    if (fileName.isEmpty())
-        goto _exit;
-
-    if (tvStreamList->model()->rowCount())
-    {
-        QMessageBox msgBox(QMessageBox::Question, qApp->applicationName(),
-                tr("Append to existing streams? Or overwrite?"),
-                QMessageBox::NoButton, this);
-        QPushButton *appendBtn = msgBox.addButton(tr("Append"), 
-                QMessageBox::ActionRole);
-        QPushButton *overwriteBtn = msgBox.addButton(tr("Overwrite"), 
-                QMessageBox::ActionRole);
-        QPushButton *cancelBtn = msgBox.addButton(QMessageBox::Cancel);
-
-        msgBox.exec();
-
-        if (msgBox.clickedButton() == cancelBtn)
-            goto _exit;
-        else if (msgBox.clickedButton() == appendBtn)
-            append = true;
-        else if (msgBox.clickedButton() == overwriteBtn)
-            append = false;
-        else
-            Q_ASSERT(false);
-    }
-
-    ret = plm->port(current).openStreams(fileName, append, errorStr);
-    if (!ret || !errorStr.isEmpty())
-    {
-        QMessageBox msgBox(this);
-        QStringList str = errorStr.split("\n\n\n\n");
-
-        msgBox.setIcon(ret ? QMessageBox::Warning : QMessageBox::Critical);
-        msgBox.setWindowTitle(qApp->applicationName());
-        msgBox.setText(str.at(0));
-        if (str.size() > 1)
-            msgBox.setDetailedText(str.at(1));
-        msgBox.setStandardButtons(QMessageBox::Ok);
-
-        msgBox.exec();
-    }
-    dirName = QFileInfo(fileName).absolutePath();
-    updateStreamViewActions();
-
-_exit:
-    return;
-}
-
-void PortsWindow::on_actionSave_Streams_triggered()
-{
-    qDebug("Save Streams Action");
-
-    QModelIndex current = tvPortList->selectionModel()->currentIndex();
-    static QString fileName;
-    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
-                                            StreamFileFormat::kSaveFile);
-    QString fileType;
-    QString errorStr;
-    QFileDialog::Options options;
-
-    if (proxyPortModel)
-        current = proxyPortModel->mapToSource(current);
-
-    // On Mac OS with Native Dialog, getSaveFileName() ignores fileType 
-    // which we need
-#if defined(Q_OS_MAC)
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
-
-    if (fileTypes.size())
-        fileType = fileTypes.at(0);
-
-    Q_ASSERT(plm->isPort(current));
-
-_retry:
-    fileName = QFileDialog::getSaveFileName(this, tr("Save Streams"),
-            fileName, fileTypes.join(";;"), &fileType, options);
-    if (fileName.isEmpty())
-        goto _exit;
-
-    if (QFileInfo(fileName).suffix().isEmpty()) {
-        QString fileExt = fileType.section(QRegExp("[\\*\\)]"), 1, 1);
-        qDebug("Adding extension '%s' to '%s'",
-                qPrintable(fileExt), qPrintable(fileName));
-        fileName.append(fileExt);
-        if (QFileInfo(fileName).exists()) {
-            if (QMessageBox::warning(this, tr("Overwrite File?"), 
-                QString("The file \"%1\" already exists.\n\n"
-                    "Do you wish to overwrite it?")
-                    .arg(QFileInfo(fileName).fileName()),
-                QMessageBox::Yes|QMessageBox::No,
-                QMessageBox::No) != QMessageBox::Yes)
-                goto _retry;
-        }
-    }
-
-    fileType = fileType.remove(QRegExp("\\(.*\\)")).trimmed();
-    if (!fileType.startsWith("Ostinato") 
-            && !fileType.startsWith("Python"))
-    {
-        if (QMessageBox::warning(this, tr("Ostinato"), 
-            QString("You have chosen to save in %1 format. All stream "
-                "attributes may not be saved in this format.\n\n"
-                "It is recommended to save in native Ostinato format.\n\n"
-                "Continue to save in %2 format?").arg(fileType).arg(fileType),
-            QMessageBox::Yes|QMessageBox::No,
-            QMessageBox::No) != QMessageBox::Yes)
-            goto _retry;
-    }
-
-    // TODO: all or selected?
-
-    if (!plm->port(current).saveStreams(fileName, fileType, errorStr))
-        QMessageBox::critical(this, qApp->applicationName(), errorStr);
-    else if (!errorStr.isEmpty())
-        QMessageBox::warning(this, qApp->applicationName(), errorStr);
-
-    fileName = QFileInfo(fileName).absolutePath();
-_exit:
-    return;
-}
-
-

--- a/client/portswindow.cpp
+++ b/client/portswindow.cpp
@@ -24,6 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "fileformat.pb.h"
 #include "portconfigdialog.h"
 #include "portgrouplist.h"
+#include "portwidget.h"
 #include "settings.h"
 #include "streamswidget.h"
 
@@ -44,6 +45,7 @@ PortsWindow::PortsWindow(PortGroupList *pgl, QWidget *parent)
 
     setupUi(this);
     applyMsg_ = new ApplyMessage();
+    portWidget->setPortGroupList(plm);
     streamsWidget->setPortGroupList(plm);
     devicesWidget->setPortGroupList(plm);
 
@@ -99,6 +101,10 @@ PortsWindow::PortsWindow(PortGroupList *pgl, QWidget *parent)
         SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), 
         this, SLOT(when_portView_currentChanged(const QModelIndex&, 
             const QModelIndex&)));
+
+    connect(this,
+            SIGNAL(currentPortChanged(const QModelIndex&, const QModelIndex&)),
+            portWidget, SLOT(setCurrentPortIndex(const QModelIndex&)));
     connect(this,
             SIGNAL(currentPortChanged(const QModelIndex&, const QModelIndex&)),
             streamsWidget, SLOT(setCurrentPortIndex(const QModelIndex&)));

--- a/client/portswindow.cpp
+++ b/client/portswindow.cpp
@@ -54,7 +54,8 @@ PortsWindow::PortsWindow(PortGroupList *pgl, QWidget *parent)
     //plm = new PortGroupList();
     plm = pgl;
 
-    setupUi(this);
+    Ui::PortsWindow::setupUi(this);
+    Ui::StreamsWidget::setupUi(streamsWidget);
     applyMsg_ = new ApplyMessage();
     devicesWidget->setPortGroupList(plm);
 

--- a/client/portswindow.h
+++ b/client/portswindow.h
@@ -23,6 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include <QWidget>
 #include <QAbstractItemModel>
 #include "ui_portswindow.h"
+#include "ui_streamswidget.h"
 #include "portgrouplist.h"
 
 class ApplyMessage;
@@ -34,7 +35,7 @@ namespace OstProto {
     class SessionContent;
 }
 
-class PortsWindow : public QWidget, private Ui::PortsWindow
+class PortsWindow : public QWidget, private Ui::PortsWindow, private Ui::StreamsWidget
 {
     Q_OBJECT
 

--- a/client/portswindow.h
+++ b/client/portswindow.h
@@ -20,14 +20,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #ifndef _PORTS_WINDOW_H
 #define _PORTS_WINDOW_H
 
-#include <QWidget>
-#include <QAbstractItemModel>
 #include "ui_portswindow.h"
-#include "ui_streamswidget.h"
-#include "portgrouplist.h"
+#include <QWidget>
 
 class ApplyMessage;
-class QAbstractItemDelegate;
+class PortGroupList;
+
 class QProgressDialog;
 class QSortFilterProxyModel;
 
@@ -35,12 +33,9 @@ namespace OstProto {
     class SessionContent;
 }
 
-class PortsWindow : public QWidget, private Ui::PortsWindow, private Ui::StreamsWidget
+class PortsWindow : public QWidget, private Ui::PortsWindow
 {
     Q_OBJECT
-
-    //QAbstractItemModel    *slm; // stream list model
-    PortGroupList        *plm;
 
 public:
     PortsWindow(PortGroupList *pgl, QWidget *parent = 0);
@@ -59,12 +54,6 @@ signals:
     void currentPortChanged(const QModelIndex &current,
                             const QModelIndex &previous);
 
-private:
-    QString        lastNewPortGroup;
-    QAbstractItemDelegate *delegate;
-    QSortFilterProxyModel *proxyPortModel;
-    ApplyMessage *applyMsg_;
-
 public slots:
     void clearCurrentSelection();
     void showMyReservedPortsOnly(bool enabled);
@@ -72,14 +61,7 @@ public slots:
 private slots:
     void updateApplyHint(int portGroupId, int portId, bool configChanged);
     void updatePortViewActions(const QModelIndex& currentIndex);
-    void updateStreamViewActions();
 
-    void on_startTx_clicked();
-    void on_stopTx_clicked();
-    void on_averagePacketsPerSec_editingFinished();
-    void on_averageBitsPerSec_editingFinished();
-    void updatePortRates();
-    void on_tvStreamList_activated(const QModelIndex & index);
     void when_portView_currentChanged(const QModelIndex& currentIndex,
         const QModelIndex& previousIndex);
     void when_portModel_dataChanged(const QModelIndex& topLeft,
@@ -96,15 +78,11 @@ private slots:
     void on_actionExclusive_Control_triggered(bool checked);
     void on_actionPort_Configuration_triggered();
 
-    void on_actionNew_Stream_triggered();
-    void on_actionEdit_Stream_triggered();
-    void on_actionDuplicate_Stream_triggered();
-    void on_actionDelete_Stream_triggered();
-
-    void on_actionOpen_Streams_triggered();
-    void on_actionSave_Streams_triggered();
-
-    void streamModelDataChanged();
+private:
+    PortGroupList *plm;
+    QString lastNewPortGroup;
+    QSortFilterProxyModel *proxyPortModel;
+    ApplyMessage *applyMsg_;
 };
 
 #endif

--- a/client/portswindow.ui
+++ b/client/portswindow.ui
@@ -213,114 +213,7 @@
            </attribute>
            <layout class="QVBoxLayout">
             <item>
-             <layout class="QHBoxLayout">
-              <item>
-               <widget class="QToolButton" name="startTx">
-                <property name="toolTip">
-                 <string>Start Transmit</string>
-                </property>
-                <property name="statusTip">
-                 <string>Start transmit on selected port</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="ostinato.qrc">
-                  <normaloff>:/icons/control_play.png</normaloff>:/icons/control_play.png</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="stopTx">
-                <property name="toolTip">
-                 <string>Stop Transmit</string>
-                </property>
-                <property name="statusTip">
-                 <string>Stop transmit on selected port</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="ostinato.qrc">
-                  <normaloff>:/icons/control_stop.png</normaloff>:/icons/control_stop.png</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer>
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="radioButton">
-                <property name="text">
-                 <string>Avg pps</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLineEdit" name="averagePacketsPerSec"/>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="radioButton_2">
-                <property name="text">
-                 <string>Avg bps</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLineEdit" name="averageBitsPerSec">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="XTableView" name="tvStreamList">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>1</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::ActionsContextMenu</enum>
-              </property>
-              <property name="whatsThis">
-               <string>This is the stream list for the selected port
-
-A stream is a sequence of one or more packets
-
-Right-click to create a stream</string>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
-              </property>
-              <property name="lineWidth">
-               <number>1</number>
-              </property>
-              <property name="selectionMode">
-               <enum>QAbstractItemView::ExtendedSelection</enum>
-              </property>
-              <property name="selectionBehavior">
-               <enum>QAbstractItemView::SelectRows</enum>
-              </property>
-             </widget>
+             <widget class="QWidget" name="streamsWidget" native="true"/>
             </item>
            </layout>
           </widget>
@@ -378,33 +271,6 @@ Right-click to create a stream</string>
     <string>Disconnect Port Group</string>
    </property>
   </action>
-  <action name="actionNew_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_add.png</normaloff>:/icons/stream_add.png</iconset>
-   </property>
-   <property name="text">
-    <string>New Stream</string>
-   </property>
-  </action>
-  <action name="actionDelete_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_delete.png</normaloff>:/icons/stream_delete.png</iconset>
-   </property>
-   <property name="text">
-    <string>Delete Stream</string>
-   </property>
-  </action>
-  <action name="actionEdit_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_edit.png</normaloff>:/icons/stream_edit.png</iconset>
-   </property>
-   <property name="text">
-    <string>Edit Stream</string>
-   </property>
-  </action>
   <action name="actionExclusive_Control">
    <property name="checkable">
     <bool>true</bool>
@@ -413,28 +279,9 @@ Right-click to create a stream</string>
     <string>Exclusive Port Control (EXPERIMENTAL)</string>
    </property>
   </action>
-  <action name="actionOpen_Streams">
-   <property name="text">
-    <string>Open Streams ...</string>
-   </property>
-  </action>
-  <action name="actionSave_Streams">
-   <property name="text">
-    <string>Save Streams ...</string>
-   </property>
-  </action>
   <action name="actionPort_Configuration">
    <property name="text">
     <string>Port Configuration ...</string>
-   </property>
-  </action>
-  <action name="actionDuplicate_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_duplicate.png</normaloff>:/icons/stream_duplicate.png</iconset>
-   </property>
-   <property name="text">
-    <string>Duplicate Stream</string>
    </property>
   </action>
  </widget>
@@ -450,47 +297,9 @@ Right-click to create a stream</string>
    <extends>QTreeView</extends>
    <header>xtreeview.h</header>
   </customwidget>
-  <customwidget>
-   <class>XTableView</class>
-   <extends>QTableView</extends>
-   <header>xtableview.h</header>
-  </customwidget>
  </customwidgets>
  <resources>
   <include location="ostinato.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>radioButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>averagePacketsPerSec</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>326</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>454</x>
-     <y>79</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>radioButton_2</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>averageBitsPerSec</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>523</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>651</x>
-     <y>88</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/client/portswindow.ui
+++ b/client/portswindow.ui
@@ -213,6 +213,9 @@
            </attribute>
            <layout class="QVBoxLayout">
             <item>
+             <widget class="PortWidget" name="portWidget" native="true"/>
+            </item>
+            <item>
              <widget class="StreamsWidget" name="streamsWidget" native="true"/>
             </item>
            </layout>
@@ -301,6 +304,12 @@
    <class>StreamsWidget</class>
    <extends>QWidget</extends>
    <header>streamswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>PortWidget</class>
+   <extends>QWidget</extends>
+   <header>portwidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/client/portswindow.ui
+++ b/client/portswindow.ui
@@ -126,7 +126,16 @@
       </widget>
       <widget class="QWidget" name="portDetail">
        <layout class="QVBoxLayout">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item>
@@ -138,7 +147,16 @@
            <enum>QFrame::Raised</enum>
           </property>
           <layout class="QHBoxLayout">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>3</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>3</number>
+           </property>
+           <property name="bottomMargin">
             <number>3</number>
            </property>
            <item>

--- a/client/portswindow.ui
+++ b/client/portswindow.ui
@@ -213,7 +213,7 @@
            </attribute>
            <layout class="QVBoxLayout">
             <item>
-             <widget class="QWidget" name="streamsWidget" native="true"/>
+             <widget class="StreamsWidget" name="streamsWidget" native="true"/>
             </item>
            </layout>
           </widget>
@@ -296,6 +296,12 @@
    <class>XTreeView</class>
    <extends>QTreeView</extends>
    <header>xtreeview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>StreamsWidget</class>
+   <extends>QWidget</extends>
+   <header>streamswidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/client/portwidget.cpp
+++ b/client/portwidget.cpp
@@ -17,122 +17,36 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-#include "streamswidget.h"
+#include "portwidget.h"
 
-#include "clipboardhelper.h"
 #include "portgrouplist.h"
-#include "streamconfigdialog.h"
-#include "streamfileformat.h"
-#include "streamlistdelegate.h"
 #include "xqlocale.h"
 
-#include <QInputDialog>
-#include <QItemSelectionModel>
-#include <QMessageBox>
-
-extern ClipboardHelper *clipboardHelper;
-
-StreamsWidget::StreamsWidget(QWidget *parent)
+PortWidget::PortWidget(QWidget *parent)
     : QWidget(parent)
 {
     setupUi(this);
-
-    delegate = new StreamListDelegate;
-    tvStreamList->setItemDelegate(delegate);
-
-    tvStreamList->verticalHeader()->setDefaultSectionSize(
-            tvStreamList->verticalHeader()->minimumSectionSize());
-
-    // Populate StreamList Context Menu Actions
-    tvStreamList->addAction(actionNew_Stream);
-    tvStreamList->addAction(actionEdit_Stream);
-    tvStreamList->addAction(actionDuplicate_Stream);
-    tvStreamList->addAction(actionDelete_Stream);
-
-    QAction *sep2 = new QAction(this);
-    sep2->setSeparator(true);
-    tvStreamList->addAction(sep2);
-
-    tvStreamList->addAction(actionOpen_Streams);
-    tvStreamList->addAction(actionSave_Streams);
-
-    // StreamWidget's actions is an aggegate of all sub-widget's actions
-    addActions(tvStreamList->actions());
-
-    // Add the clipboard actions to the context menu of streamList
-    // but not to StreamsWidget's actions since they are already available
-    // in the global Edit Menu
-    QAction *sep3 = new QAction("Clipboard", this);
-    sep3->setSeparator(true);
-    tvStreamList->insertAction(sep2, sep3);
-    tvStreamList->insertActions(sep2, clipboardHelper->actions());
 }
 
-void StreamsWidget::setPortGroupList(PortGroupList *portGroups)
+void PortWidget::setPortGroupList(PortGroupList *portGroups)
 {
     plm = portGroups;
 
-    tvStreamList->setModel(plm->getStreamModel());
-
     connect(plm->getStreamModel(), SIGNAL(rowsInserted(QModelIndex, int, int)), 
-        SLOT(updateStreamViewActions()));
+        SLOT(updatePortActions()));
     connect(plm->getStreamModel(), SIGNAL(rowsRemoved(QModelIndex, int, int)), 
-        SLOT(updateStreamViewActions()));
+        SLOT(updatePortActions()));
+    connect(plm->getStreamModel(), SIGNAL(modelReset()), 
+        SLOT(updatePortActions()));
 
-    connect(tvStreamList->selectionModel(), 
-        SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), 
-        SLOT(updateStreamViewActions()));
-    connect(tvStreamList->selectionModel(), 
-        SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
-        SLOT(updateStreamViewActions()));
-
-    tvStreamList->resizeColumnToContents(StreamModel::StreamIcon);
-    tvStreamList->resizeColumnToContents(StreamModel::StreamStatus);
-
-    updateStreamViewActions();
-
-    connect(plm->getStreamModel(), 
-        SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)), 
-        this, SLOT(streamModelDataChanged()));
-    connect(plm->getStreamModel(), 
-        SIGNAL(modelReset()), 
-        this, SLOT(streamModelDataChanged()));
+    updatePortActions();
 }
 
-void StreamsWidget::streamModelDataChanged()
+PortWidget::~PortWidget()
 {
-    if (plm->isPort(currentPortIndex_))
-        plm->port(currentPortIndex_).recalculateAverageRates();
 }
 
-StreamsWidget::~StreamsWidget()
-{
-    delete delegate;
-}
-
-void StreamsWidget::on_tvStreamList_activated(const QModelIndex & index)
-{
-    if (!index.isValid())
-    {
-        qDebug("%s: invalid index", __FUNCTION__);
-        return;
-    }
-
-    qDebug("stream list activated\n");
-
-    Port &curPort = plm->port(currentPortIndex_);
-
-    QList<Stream*> streams;
-    streams.append(curPort.mutableStreamByIndex(index.row(), false));
-
-    StreamConfigDialog scd(streams, curPort, this);
-    if (scd.exec() == QDialog::Accepted) {
-        curPort.recalculateAverageRates();
-        curPort.setLocalConfigChanged(true);
-    }
-}
-
-void StreamsWidget::setCurrentPortIndex(const QModelIndex &portIndex)
+void PortWidget::setCurrentPortIndex(const QModelIndex &portIndex)
 {
     if (!plm)
         return;
@@ -150,18 +64,18 @@ void StreamsWidget::setCurrentPortIndex(const QModelIndex &portIndex)
                 this, SLOT(updatePortRates()));
 
     currentPortIndex_ = portIndex;
-    plm->getStreamModel()->setCurrentPortIndex(portIndex);
 
     // Connect current port
     if (plm->isPort(currentPortIndex_))
         connect(&(plm->port(currentPortIndex_)),
                 SIGNAL(portRateChanged(int, int)),
                 this, SLOT(updatePortRates()));
+
     updatePortRates();
-    updateStreamViewActions();
+    updatePortActions();
 }
 
-void StreamsWidget::on_startTx_clicked()
+void PortWidget::on_startTx_clicked()
 {
     Q_ASSERT(plm->isPort(currentPortIndex_));
 
@@ -173,7 +87,7 @@ void StreamsWidget::on_startTx_clicked()
     plm->portGroup(curPortGroup).startTx(&portList);
 }
 
-void StreamsWidget::on_stopTx_clicked()
+void PortWidget::on_stopTx_clicked()
 {
     Q_ASSERT(plm->isPort(currentPortIndex_));
 
@@ -185,7 +99,7 @@ void StreamsWidget::on_stopTx_clicked()
     plm->portGroup(curPortGroup).stopTx(&portList);
 }
 
-void StreamsWidget::on_averagePacketsPerSec_editingFinished()
+void PortWidget::on_averagePacketsPerSec_editingFinished()
 {
     Q_ASSERT(plm->isPort(currentPortIndex_));
 
@@ -195,7 +109,7 @@ void StreamsWidget::on_averagePacketsPerSec_editingFinished()
     plm->port(currentPortIndex_).setAveragePacketRate(pps);
 }
 
-void StreamsWidget::on_averageBitsPerSec_editingFinished()
+void PortWidget::on_averageBitsPerSec_editingFinished()
 {
     Q_ASSERT(plm->isPort(currentPortIndex_));
 
@@ -205,7 +119,7 @@ void StreamsWidget::on_averageBitsPerSec_editingFinished()
     plm->port(currentPortIndex_).setAverageBitRate(bps);
 }
 
-void StreamsWidget::updatePortRates()
+void PortWidget::updatePortRates()
 {
     if (!currentPortIndex_.isValid())
         return;
@@ -219,287 +133,11 @@ void StreamsWidget::updatePortRates()
             .arg(plm->port(currentPortIndex_).averageBitRate(), 0, 'f', 0));
 }
 
-void StreamsWidget::updateStreamViewActions()
+void PortWidget::updatePortActions()
 {
-    // For some reason hasSelection() returns true even if selection size is 0
-    // so additional check for size introduced
-    if (tvStreamList->selectionModel()->hasSelection() &&
-        (tvStreamList->selectionModel()->selection().size() > 0))
-    {
-        qDebug("Has selection %d",
-            tvStreamList->selectionModel()->selection().size());
-
-        // If more than one non-contiguous ranges selected,
-        // disable "New" and "Edit"
-        if (tvStreamList->selectionModel()->selection().size() > 1)
-        {
-            actionNew_Stream->setDisabled(true);
-            actionEdit_Stream->setDisabled(true);
-        }
-        else
-        {
-            actionNew_Stream->setEnabled(true);
-            actionEdit_Stream->setEnabled(true);
-        }
-
-        // Duplicate/Delete are always enabled as long as we have a selection
-        actionDuplicate_Stream->setEnabled(true);
-        actionDelete_Stream->setEnabled(true);
-    }
-    else
-    {
-        qDebug("No selection");
-        if (plm->isPort(currentPortIndex_))
-            actionNew_Stream->setEnabled(true);
-        else
-            actionNew_Stream->setDisabled(true);
-        actionEdit_Stream->setDisabled(true);
-        actionDuplicate_Stream->setDisabled(true);
-        actionDelete_Stream->setDisabled(true);
-    }
-    actionOpen_Streams->setEnabled(plm->isPort(currentPortIndex_));
-    actionSave_Streams->setEnabled(tvStreamList->model()->rowCount() > 0);
-
-    startTx->setEnabled(tvStreamList->model()->rowCount() > 0);
-    stopTx->setEnabled(tvStreamList->model()->rowCount() > 0);
-}
-
-void StreamsWidget::on_actionNew_Stream_triggered()
-{
-    qDebug("New Stream Action");
-
-    QItemSelectionModel* selectionModel = tvStreamList->selectionModel();
-    if (selectionModel->selection().size() > 1) {
-        qDebug("%s: Unexpected selection size %d, can't add", __FUNCTION__,
-                selectionModel->selection().size());
-        return;
-    }
-
-    // In case nothing is selected, insert 1 row at the end
-    StreamModel *streamModel = plm->getStreamModel();
-    int row = streamModel->rowCount(), count = 1;
-
-    // In case we have a single range selected; insert as many rows as
-    // in the singe selected range before the top of the selected range
-    if (selectionModel->selection().size() == 1)
-    {
-        row = selectionModel->selection().at(0).top();
-        count = selectionModel->selection().at(0).height();
-    }
-
-    Port &curPort = plm->port(currentPortIndex_);
-
-    QList<Stream*> streams;
-    for (int i = 0; i < count; i++)
-        streams.append(new Stream);
-
-    StreamConfigDialog scd(streams, curPort, this);
-    scd.setWindowTitle(tr("Add Stream"));
-    if (scd.exec() == QDialog::Accepted)
-        streamModel->insert(row, streams);
-}
-
-void StreamsWidget::on_actionEdit_Stream_triggered()
-{
-    qDebug("Edit Stream Action");
-
-    QItemSelectionModel* streamModel = tvStreamList->selectionModel();
-    if (!streamModel->hasSelection())
+    if (!plm->isPort(currentPortIndex_))
         return;
 
-    Port &curPort = plm->port(currentPortIndex_);
-
-    QList<Stream*> streams;
-    foreach(QModelIndex index, streamModel->selectedRows())
-        streams.append(curPort.mutableStreamByIndex(index.row(), false));
-
-    StreamConfigDialog scd(streams, curPort, this);
-    if (scd.exec() == QDialog::Accepted) {
-        curPort.recalculateAverageRates();
-        curPort.setLocalConfigChanged(true);
-    }
+    startTx->setEnabled(plm->port(currentPortIndex_).numStreams() > 0);
+    stopTx->setEnabled(plm->port(currentPortIndex_).numStreams() > 0);
 }
-
-void StreamsWidget::on_actionDuplicate_Stream_triggered()
-{
-    QItemSelectionModel* model = tvStreamList->selectionModel();
-
-    qDebug("Duplicate Stream Action");
-
-    if (model->hasSelection())
-    {
-        bool isOk;
-        int count = QInputDialog::getInt(this, "Duplicate Streams",
-                "Count", 1, 1, 9999, 1, &isOk);
-
-        if (!isOk)
-            return;
-
-        QList<int> list;
-        foreach(QModelIndex index, model->selectedRows())
-            list.append(index.row());
-        plm->port(currentPortIndex_).duplicateStreams(list, count);
-    }
-    else
-        qDebug("No selection");
-}
-
-void StreamsWidget::on_actionDelete_Stream_triggered()
-{
-    qDebug("Delete Stream Action");
-
-    QModelIndex        index;
-
-    if (tvStreamList->selectionModel()->hasSelection())
-    {
-        qDebug("SelectedIndexes %d",
-            tvStreamList->selectionModel()->selectedRows().size());
-        while(tvStreamList->selectionModel()->selectedRows().size())
-        {
-            index = tvStreamList->selectionModel()->selectedRows().at(0);
-            plm->getStreamModel()->removeRows(index.row(), 1);    
-        }
-    }
-    else
-        qDebug("No selection");
-}
-
-void StreamsWidget::on_actionOpen_Streams_triggered()
-{
-    qDebug("Open Streams Action");
-
-    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
-                                            StreamFileFormat::kOpenFile);
-    QString fileType;
-    static QString dirName;
-    QString fileName;
-    QString errorStr;
-    bool append = true;
-    bool ret;
-
-    Q_ASSERT(plm->isPort(currentPortIndex_));
-
-    if (fileTypes.size())
-        fileType = fileTypes.at(0);
-
-    fileName = QFileDialog::getOpenFileName(this, tr("Open Streams"),
-            dirName, fileTypes.join(";;"), &fileType);
-    if (fileName.isEmpty())
-        goto _exit;
-
-    if (tvStreamList->model()->rowCount())
-    {
-        QMessageBox msgBox(QMessageBox::Question, qApp->applicationName(),
-                tr("Append to existing streams? Or overwrite?"),
-                QMessageBox::NoButton, this);
-        QPushButton *appendBtn = msgBox.addButton(tr("Append"), 
-                QMessageBox::ActionRole);
-        QPushButton *overwriteBtn = msgBox.addButton(tr("Overwrite"), 
-                QMessageBox::ActionRole);
-        QPushButton *cancelBtn = msgBox.addButton(QMessageBox::Cancel);
-
-        msgBox.exec();
-
-        if (msgBox.clickedButton() == cancelBtn)
-            goto _exit;
-        else if (msgBox.clickedButton() == appendBtn)
-            append = true;
-        else if (msgBox.clickedButton() == overwriteBtn)
-            append = false;
-        else
-            Q_ASSERT(false);
-    }
-
-    ret = plm->port(currentPortIndex_).openStreams(fileName, append, errorStr);
-    if (!ret || !errorStr.isEmpty())
-    {
-        QMessageBox msgBox(this);
-        QStringList str = errorStr.split("\n\n\n\n");
-
-        msgBox.setIcon(ret ? QMessageBox::Warning : QMessageBox::Critical);
-        msgBox.setWindowTitle(qApp->applicationName());
-        msgBox.setText(str.at(0));
-        if (str.size() > 1)
-            msgBox.setDetailedText(str.at(1));
-        msgBox.setStandardButtons(QMessageBox::Ok);
-
-        msgBox.exec();
-    }
-    dirName = QFileInfo(fileName).absolutePath();
-    updateStreamViewActions();
-
-_exit:
-    return;
-}
-
-void StreamsWidget::on_actionSave_Streams_triggered()
-{
-    qDebug("Save Streams Action");
-
-    static QString fileName;
-    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
-                                            StreamFileFormat::kSaveFile);
-    QString fileType;
-    QString errorStr;
-    QFileDialog::Options options;
-
-    // On Mac OS with Native Dialog, getSaveFileName() ignores fileType 
-    // which we need
-#if defined(Q_OS_MAC)
-    options |= QFileDialog::DontUseNativeDialog;
-#endif
-
-    if (fileTypes.size())
-        fileType = fileTypes.at(0);
-
-    Q_ASSERT(plm->isPort(currentPortIndex_));
-
-_retry:
-    fileName = QFileDialog::getSaveFileName(this, tr("Save Streams"),
-            fileName, fileTypes.join(";;"), &fileType, options);
-    if (fileName.isEmpty())
-        goto _exit;
-
-    if (QFileInfo(fileName).suffix().isEmpty()) {
-        QString fileExt = fileType.section(QRegExp("[\\*\\)]"), 1, 1);
-        qDebug("Adding extension '%s' to '%s'",
-                qPrintable(fileExt), qPrintable(fileName));
-        fileName.append(fileExt);
-        if (QFileInfo(fileName).exists()) {
-            if (QMessageBox::warning(this, tr("Overwrite File?"), 
-                QString("The file \"%1\" already exists.\n\n"
-                    "Do you wish to overwrite it?")
-                    .arg(QFileInfo(fileName).fileName()),
-                QMessageBox::Yes|QMessageBox::No,
-                QMessageBox::No) != QMessageBox::Yes)
-                goto _retry;
-        }
-    }
-
-    fileType = fileType.remove(QRegExp("\\(.*\\)")).trimmed();
-    if (!fileType.startsWith("Ostinato") 
-            && !fileType.startsWith("Python"))
-    {
-        if (QMessageBox::warning(this, tr("Ostinato"), 
-            QString("You have chosen to save in %1 format. All stream "
-                "attributes may not be saved in this format.\n\n"
-                "It is recommended to save in native Ostinato format.\n\n"
-                "Continue to save in %2 format?").arg(fileType).arg(fileType),
-            QMessageBox::Yes|QMessageBox::No,
-            QMessageBox::No) != QMessageBox::Yes)
-            goto _retry;
-    }
-
-    // TODO: all or selected?
-
-    if (!plm->port(currentPortIndex_).saveStreams(fileName, fileType, errorStr))
-        QMessageBox::critical(this, qApp->applicationName(), errorStr);
-    else if (!errorStr.isEmpty())
-        QMessageBox::warning(this, qApp->applicationName(), errorStr);
-
-    fileName = QFileInfo(fileName).absolutePath();
-_exit:
-    return;
-}
-
-

--- a/client/portwidget.cpp
+++ b/client/portwidget.cpp
@@ -122,9 +122,13 @@ void PortWidget::on_averagePacketsPerSec_editingFinished()
     Q_ASSERT(plm->isPort(currentPortIndex_));
 
     bool isOk;
-    double pps = XLocale().toDouble(averagePacketsPerSec->text(), &isOk);
+    double pps = XLocale().toPacketsPerSecond(averagePacketsPerSec->text(),
+                                              &isOk);
 
-    plm->port(currentPortIndex_).setAveragePacketRate(pps);
+    if (isOk)
+        plm->port(currentPortIndex_).setAveragePacketRate(pps);
+    else
+        updatePortRates();
 }
 
 void PortWidget::on_averageBitsPerSec_editingFinished()
@@ -132,9 +136,12 @@ void PortWidget::on_averageBitsPerSec_editingFinished()
     Q_ASSERT(plm->isPort(currentPortIndex_));
 
     bool isOk;
-    double bps = XLocale().toDouble(averageBitsPerSec->text(), &isOk);
+    double bps = XLocale().toBitsPerSecond(averageBitsPerSec->text(), &isOk);
 
-    plm->port(currentPortIndex_).setAverageBitRate(bps);
+    if (isOk)
+        plm->port(currentPortIndex_).setAverageBitRate(bps);
+    else
+        updatePortRates();
 }
 
 void PortWidget::updatePortRates()
@@ -147,7 +154,7 @@ void PortWidget::updatePortRates()
 
     // XXX: pps/bps input widget is a LineEdit and not a SpinBox
     // because we want users to be able to enter values in various
-    // units e.g. 1.5 Mbps, 1000K, 50 etc.
+    // units e.g. "1.5 Mbps", "1000K", "50" (bps) etc.
 
     // XXX: It's a considered decision NOT to show frame rate in
     // higher units of Kpps and Mpps as most users may not be
@@ -158,15 +165,8 @@ void PortWidget::updatePortRates()
     averagePacketsPerSec->setText(QString("%L1 pps")
             .arg(plm->port(currentPortIndex_).averagePacketRate(), 0, 'f', 4));
 
-    double bps = plm->port(currentPortIndex_).averageBitRate();
-    if (bps > 1e9)
-        averageBitsPerSec->setText(tr("%L1 Gbps").arg(bps/1e9, 0, 'f', 4));
-    else if (bps > 1e6)
-        averageBitsPerSec->setText(tr("%L1 Mbps").arg(bps/1e6, 0, 'f', 4));
-    else if (bps > 1e3)
-        averageBitsPerSec->setText(tr("%L1 Kbps").arg(bps/1e3, 0, 'f', 4));
-    else
-        averageBitsPerSec->setText(tr("%L1 bps").arg(bps, 0, 'f', 4));
+    averageBitsPerSec->setText(XLocale().toBitRateString(
+                plm->port(currentPortIndex_).averageBitRate()));
 
     averageLoadPercent->setValue(
             plm->port(currentPortIndex_).averageLoadRate()*100);

--- a/client/portwidget.cpp
+++ b/client/portwidget.cpp
@@ -28,7 +28,6 @@ PortWidget::PortWidget(QWidget *parent)
     : QWidget(parent)
 {
     setupUi(this);
-    averageLoadPercent->setMaximum(DBL_MAX);
 }
 
 void PortWidget::setPortGroupList(PortGroupList *portGroups)

--- a/client/portwidget.cpp
+++ b/client/portwidget.cpp
@@ -1,0 +1,505 @@
+/*
+Copyright (C) 2010 Srivats P.
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#include "streamswidget.h"
+
+#include "clipboardhelper.h"
+#include "portgrouplist.h"
+#include "streamconfigdialog.h"
+#include "streamfileformat.h"
+#include "streamlistdelegate.h"
+#include "xqlocale.h"
+
+#include <QInputDialog>
+#include <QItemSelectionModel>
+#include <QMessageBox>
+
+extern ClipboardHelper *clipboardHelper;
+
+StreamsWidget::StreamsWidget(QWidget *parent)
+    : QWidget(parent)
+{
+    setupUi(this);
+
+    delegate = new StreamListDelegate;
+    tvStreamList->setItemDelegate(delegate);
+
+    tvStreamList->verticalHeader()->setDefaultSectionSize(
+            tvStreamList->verticalHeader()->minimumSectionSize());
+
+    // Populate StreamList Context Menu Actions
+    tvStreamList->addAction(actionNew_Stream);
+    tvStreamList->addAction(actionEdit_Stream);
+    tvStreamList->addAction(actionDuplicate_Stream);
+    tvStreamList->addAction(actionDelete_Stream);
+
+    QAction *sep2 = new QAction(this);
+    sep2->setSeparator(true);
+    tvStreamList->addAction(sep2);
+
+    tvStreamList->addAction(actionOpen_Streams);
+    tvStreamList->addAction(actionSave_Streams);
+
+    // StreamWidget's actions is an aggegate of all sub-widget's actions
+    addActions(tvStreamList->actions());
+
+    // Add the clipboard actions to the context menu of streamList
+    // but not to StreamsWidget's actions since they are already available
+    // in the global Edit Menu
+    QAction *sep3 = new QAction("Clipboard", this);
+    sep3->setSeparator(true);
+    tvStreamList->insertAction(sep2, sep3);
+    tvStreamList->insertActions(sep2, clipboardHelper->actions());
+}
+
+void StreamsWidget::setPortGroupList(PortGroupList *portGroups)
+{
+    plm = portGroups;
+
+    tvStreamList->setModel(plm->getStreamModel());
+
+    connect(plm->getStreamModel(), SIGNAL(rowsInserted(QModelIndex, int, int)), 
+        SLOT(updateStreamViewActions()));
+    connect(plm->getStreamModel(), SIGNAL(rowsRemoved(QModelIndex, int, int)), 
+        SLOT(updateStreamViewActions()));
+
+    connect(tvStreamList->selectionModel(), 
+        SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), 
+        SLOT(updateStreamViewActions()));
+    connect(tvStreamList->selectionModel(), 
+        SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
+        SLOT(updateStreamViewActions()));
+
+    tvStreamList->resizeColumnToContents(StreamModel::StreamIcon);
+    tvStreamList->resizeColumnToContents(StreamModel::StreamStatus);
+
+    updateStreamViewActions();
+
+    connect(plm->getStreamModel(), 
+        SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)), 
+        this, SLOT(streamModelDataChanged()));
+    connect(plm->getStreamModel(), 
+        SIGNAL(modelReset()), 
+        this, SLOT(streamModelDataChanged()));
+}
+
+void StreamsWidget::streamModelDataChanged()
+{
+    if (plm->isPort(currentPortIndex_))
+        plm->port(currentPortIndex_).recalculateAverageRates();
+}
+
+StreamsWidget::~StreamsWidget()
+{
+    delete delegate;
+}
+
+void StreamsWidget::on_tvStreamList_activated(const QModelIndex & index)
+{
+    if (!index.isValid())
+    {
+        qDebug("%s: invalid index", __FUNCTION__);
+        return;
+    }
+
+    qDebug("stream list activated\n");
+
+    Port &curPort = plm->port(currentPortIndex_);
+
+    QList<Stream*> streams;
+    streams.append(curPort.mutableStreamByIndex(index.row(), false));
+
+    StreamConfigDialog scd(streams, curPort, this);
+    if (scd.exec() == QDialog::Accepted) {
+        curPort.recalculateAverageRates();
+        curPort.setLocalConfigChanged(true);
+    }
+}
+
+void StreamsWidget::setCurrentPortIndex(const QModelIndex &portIndex)
+{
+    if (!plm)
+        return;
+
+    // XXX: We assume portIndex corresponds to sourceModel, not proxyModel
+    if (!plm->isPort(portIndex))
+        return;
+
+    qDebug("In %s", __FUNCTION__);
+
+    // Disconnect previous port
+    if (plm->isPort(currentPortIndex_))
+        disconnect(&(plm->port(currentPortIndex_)),
+                SIGNAL(portRateChanged(int, int)),
+                this, SLOT(updatePortRates()));
+
+    currentPortIndex_ = portIndex;
+    plm->getStreamModel()->setCurrentPortIndex(portIndex);
+
+    // Connect current port
+    if (plm->isPort(currentPortIndex_))
+        connect(&(plm->port(currentPortIndex_)),
+                SIGNAL(portRateChanged(int, int)),
+                this, SLOT(updatePortRates()));
+    updatePortRates();
+    updateStreamViewActions();
+}
+
+void StreamsWidget::on_startTx_clicked()
+{
+    Q_ASSERT(plm->isPort(currentPortIndex_));
+
+    QModelIndex curPortGroup = plm->getPortModel()->parent(currentPortIndex_);
+    Q_ASSERT(curPortGroup.isValid());
+    Q_ASSERT(plm->isPortGroup(curPortGroup));
+
+    QList<uint> portList({plm->port(currentPortIndex_).id()});
+    plm->portGroup(curPortGroup).startTx(&portList);
+}
+
+void StreamsWidget::on_stopTx_clicked()
+{
+    Q_ASSERT(plm->isPort(currentPortIndex_));
+
+    QModelIndex curPortGroup = plm->getPortModel()->parent(currentPortIndex_);
+    Q_ASSERT(curPortGroup.isValid());
+    Q_ASSERT(plm->isPortGroup(curPortGroup));
+
+    QList<uint> portList({plm->port(currentPortIndex_).id()});
+    plm->portGroup(curPortGroup).stopTx(&portList);
+}
+
+void StreamsWidget::on_averagePacketsPerSec_editingFinished()
+{
+    Q_ASSERT(plm->isPort(currentPortIndex_));
+
+    bool isOk;
+    double pps = XLocale().toDouble(averagePacketsPerSec->text(), &isOk);
+
+    plm->port(currentPortIndex_).setAveragePacketRate(pps);
+}
+
+void StreamsWidget::on_averageBitsPerSec_editingFinished()
+{
+    Q_ASSERT(plm->isPort(currentPortIndex_));
+
+    bool isOk;
+    double bps = XLocale().toDouble(averageBitsPerSec->text(), &isOk);
+
+    plm->port(currentPortIndex_).setAverageBitRate(bps);
+}
+
+void StreamsWidget::updatePortRates()
+{
+    if (!currentPortIndex_.isValid())
+        return;
+
+    if (!plm->isPort(currentPortIndex_))
+        return;
+
+    averagePacketsPerSec->setText(QString("%L1")
+            .arg(plm->port(currentPortIndex_).averagePacketRate(), 0, 'f', 4));
+    averageBitsPerSec->setText(QString("%L1")
+            .arg(plm->port(currentPortIndex_).averageBitRate(), 0, 'f', 0));
+}
+
+void StreamsWidget::updateStreamViewActions()
+{
+    // For some reason hasSelection() returns true even if selection size is 0
+    // so additional check for size introduced
+    if (tvStreamList->selectionModel()->hasSelection() &&
+        (tvStreamList->selectionModel()->selection().size() > 0))
+    {
+        qDebug("Has selection %d",
+            tvStreamList->selectionModel()->selection().size());
+
+        // If more than one non-contiguous ranges selected,
+        // disable "New" and "Edit"
+        if (tvStreamList->selectionModel()->selection().size() > 1)
+        {
+            actionNew_Stream->setDisabled(true);
+            actionEdit_Stream->setDisabled(true);
+        }
+        else
+        {
+            actionNew_Stream->setEnabled(true);
+            actionEdit_Stream->setEnabled(true);
+        }
+
+        // Duplicate/Delete are always enabled as long as we have a selection
+        actionDuplicate_Stream->setEnabled(true);
+        actionDelete_Stream->setEnabled(true);
+    }
+    else
+    {
+        qDebug("No selection");
+        if (plm->isPort(currentPortIndex_))
+            actionNew_Stream->setEnabled(true);
+        else
+            actionNew_Stream->setDisabled(true);
+        actionEdit_Stream->setDisabled(true);
+        actionDuplicate_Stream->setDisabled(true);
+        actionDelete_Stream->setDisabled(true);
+    }
+    actionOpen_Streams->setEnabled(plm->isPort(currentPortIndex_));
+    actionSave_Streams->setEnabled(tvStreamList->model()->rowCount() > 0);
+
+    startTx->setEnabled(tvStreamList->model()->rowCount() > 0);
+    stopTx->setEnabled(tvStreamList->model()->rowCount() > 0);
+}
+
+void StreamsWidget::on_actionNew_Stream_triggered()
+{
+    qDebug("New Stream Action");
+
+    QItemSelectionModel* selectionModel = tvStreamList->selectionModel();
+    if (selectionModel->selection().size() > 1) {
+        qDebug("%s: Unexpected selection size %d, can't add", __FUNCTION__,
+                selectionModel->selection().size());
+        return;
+    }
+
+    // In case nothing is selected, insert 1 row at the end
+    StreamModel *streamModel = plm->getStreamModel();
+    int row = streamModel->rowCount(), count = 1;
+
+    // In case we have a single range selected; insert as many rows as
+    // in the singe selected range before the top of the selected range
+    if (selectionModel->selection().size() == 1)
+    {
+        row = selectionModel->selection().at(0).top();
+        count = selectionModel->selection().at(0).height();
+    }
+
+    Port &curPort = plm->port(currentPortIndex_);
+
+    QList<Stream*> streams;
+    for (int i = 0; i < count; i++)
+        streams.append(new Stream);
+
+    StreamConfigDialog scd(streams, curPort, this);
+    scd.setWindowTitle(tr("Add Stream"));
+    if (scd.exec() == QDialog::Accepted)
+        streamModel->insert(row, streams);
+}
+
+void StreamsWidget::on_actionEdit_Stream_triggered()
+{
+    qDebug("Edit Stream Action");
+
+    QItemSelectionModel* streamModel = tvStreamList->selectionModel();
+    if (!streamModel->hasSelection())
+        return;
+
+    Port &curPort = plm->port(currentPortIndex_);
+
+    QList<Stream*> streams;
+    foreach(QModelIndex index, streamModel->selectedRows())
+        streams.append(curPort.mutableStreamByIndex(index.row(), false));
+
+    StreamConfigDialog scd(streams, curPort, this);
+    if (scd.exec() == QDialog::Accepted) {
+        curPort.recalculateAverageRates();
+        curPort.setLocalConfigChanged(true);
+    }
+}
+
+void StreamsWidget::on_actionDuplicate_Stream_triggered()
+{
+    QItemSelectionModel* model = tvStreamList->selectionModel();
+
+    qDebug("Duplicate Stream Action");
+
+    if (model->hasSelection())
+    {
+        bool isOk;
+        int count = QInputDialog::getInt(this, "Duplicate Streams",
+                "Count", 1, 1, 9999, 1, &isOk);
+
+        if (!isOk)
+            return;
+
+        QList<int> list;
+        foreach(QModelIndex index, model->selectedRows())
+            list.append(index.row());
+        plm->port(currentPortIndex_).duplicateStreams(list, count);
+    }
+    else
+        qDebug("No selection");
+}
+
+void StreamsWidget::on_actionDelete_Stream_triggered()
+{
+    qDebug("Delete Stream Action");
+
+    QModelIndex        index;
+
+    if (tvStreamList->selectionModel()->hasSelection())
+    {
+        qDebug("SelectedIndexes %d",
+            tvStreamList->selectionModel()->selectedRows().size());
+        while(tvStreamList->selectionModel()->selectedRows().size())
+        {
+            index = tvStreamList->selectionModel()->selectedRows().at(0);
+            plm->getStreamModel()->removeRows(index.row(), 1);    
+        }
+    }
+    else
+        qDebug("No selection");
+}
+
+void StreamsWidget::on_actionOpen_Streams_triggered()
+{
+    qDebug("Open Streams Action");
+
+    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
+                                            StreamFileFormat::kOpenFile);
+    QString fileType;
+    static QString dirName;
+    QString fileName;
+    QString errorStr;
+    bool append = true;
+    bool ret;
+
+    Q_ASSERT(plm->isPort(currentPortIndex_));
+
+    if (fileTypes.size())
+        fileType = fileTypes.at(0);
+
+    fileName = QFileDialog::getOpenFileName(this, tr("Open Streams"),
+            dirName, fileTypes.join(";;"), &fileType);
+    if (fileName.isEmpty())
+        goto _exit;
+
+    if (tvStreamList->model()->rowCount())
+    {
+        QMessageBox msgBox(QMessageBox::Question, qApp->applicationName(),
+                tr("Append to existing streams? Or overwrite?"),
+                QMessageBox::NoButton, this);
+        QPushButton *appendBtn = msgBox.addButton(tr("Append"), 
+                QMessageBox::ActionRole);
+        QPushButton *overwriteBtn = msgBox.addButton(tr("Overwrite"), 
+                QMessageBox::ActionRole);
+        QPushButton *cancelBtn = msgBox.addButton(QMessageBox::Cancel);
+
+        msgBox.exec();
+
+        if (msgBox.clickedButton() == cancelBtn)
+            goto _exit;
+        else if (msgBox.clickedButton() == appendBtn)
+            append = true;
+        else if (msgBox.clickedButton() == overwriteBtn)
+            append = false;
+        else
+            Q_ASSERT(false);
+    }
+
+    ret = plm->port(currentPortIndex_).openStreams(fileName, append, errorStr);
+    if (!ret || !errorStr.isEmpty())
+    {
+        QMessageBox msgBox(this);
+        QStringList str = errorStr.split("\n\n\n\n");
+
+        msgBox.setIcon(ret ? QMessageBox::Warning : QMessageBox::Critical);
+        msgBox.setWindowTitle(qApp->applicationName());
+        msgBox.setText(str.at(0));
+        if (str.size() > 1)
+            msgBox.setDetailedText(str.at(1));
+        msgBox.setStandardButtons(QMessageBox::Ok);
+
+        msgBox.exec();
+    }
+    dirName = QFileInfo(fileName).absolutePath();
+    updateStreamViewActions();
+
+_exit:
+    return;
+}
+
+void StreamsWidget::on_actionSave_Streams_triggered()
+{
+    qDebug("Save Streams Action");
+
+    static QString fileName;
+    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
+                                            StreamFileFormat::kSaveFile);
+    QString fileType;
+    QString errorStr;
+    QFileDialog::Options options;
+
+    // On Mac OS with Native Dialog, getSaveFileName() ignores fileType 
+    // which we need
+#if defined(Q_OS_MAC)
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+
+    if (fileTypes.size())
+        fileType = fileTypes.at(0);
+
+    Q_ASSERT(plm->isPort(currentPortIndex_));
+
+_retry:
+    fileName = QFileDialog::getSaveFileName(this, tr("Save Streams"),
+            fileName, fileTypes.join(";;"), &fileType, options);
+    if (fileName.isEmpty())
+        goto _exit;
+
+    if (QFileInfo(fileName).suffix().isEmpty()) {
+        QString fileExt = fileType.section(QRegExp("[\\*\\)]"), 1, 1);
+        qDebug("Adding extension '%s' to '%s'",
+                qPrintable(fileExt), qPrintable(fileName));
+        fileName.append(fileExt);
+        if (QFileInfo(fileName).exists()) {
+            if (QMessageBox::warning(this, tr("Overwrite File?"), 
+                QString("The file \"%1\" already exists.\n\n"
+                    "Do you wish to overwrite it?")
+                    .arg(QFileInfo(fileName).fileName()),
+                QMessageBox::Yes|QMessageBox::No,
+                QMessageBox::No) != QMessageBox::Yes)
+                goto _retry;
+        }
+    }
+
+    fileType = fileType.remove(QRegExp("\\(.*\\)")).trimmed();
+    if (!fileType.startsWith("Ostinato") 
+            && !fileType.startsWith("Python"))
+    {
+        if (QMessageBox::warning(this, tr("Ostinato"), 
+            QString("You have chosen to save in %1 format. All stream "
+                "attributes may not be saved in this format.\n\n"
+                "It is recommended to save in native Ostinato format.\n\n"
+                "Continue to save in %2 format?").arg(fileType).arg(fileType),
+            QMessageBox::Yes|QMessageBox::No,
+            QMessageBox::No) != QMessageBox::Yes)
+            goto _retry;
+    }
+
+    // TODO: all or selected?
+
+    if (!plm->port(currentPortIndex_).saveStreams(fileName, fileType, errorStr))
+        QMessageBox::critical(this, qApp->applicationName(), errorStr);
+    else if (!errorStr.isEmpty())
+        QMessageBox::warning(this, qApp->applicationName(), errorStr);
+
+    fileName = QFileInfo(fileName).absolutePath();
+_exit:
+    return;
+}
+
+

--- a/client/portwidget.cpp
+++ b/client/portwidget.cpp
@@ -117,7 +117,6 @@ void PortWidget::on_averageLoadPercent_editingFinished()
             averageLoadPercent->value()/100);
 }
 
-
 void PortWidget::on_averagePacketsPerSec_editingFinished()
 {
     Q_ASSERT(plm->isPort(currentPortIndex_));
@@ -146,12 +145,31 @@ void PortWidget::updatePortRates()
     if (!plm->isPort(currentPortIndex_))
         return;
 
+    // XXX: pps/bps input widget is a LineEdit and not a SpinBox
+    // because we want users to be able to enter values in various
+    // units e.g. 1.5 Mbps, 1000K, 50 etc.
+
+    // XXX: It's a considered decision NOT to show frame rate in
+    // higher units of Kpps and Mpps as most users may not be
+    // familiar with those and also we want frame rate to have a
+    // high resolution for input e.g. if user enters 1,488,095.2381
+    // it should NOT be shown as 1.4881 Mpps
+
+    averagePacketsPerSec->setText(QString("%L1 pps")
+            .arg(plm->port(currentPortIndex_).averagePacketRate(), 0, 'f', 4));
+
+    double bps = plm->port(currentPortIndex_).averageBitRate();
+    if (bps > 1e9)
+        averageBitsPerSec->setText(tr("%L1 Gbps").arg(bps/1e9, 0, 'f', 4));
+    else if (bps > 1e6)
+        averageBitsPerSec->setText(tr("%L1 Mbps").arg(bps/1e6, 0, 'f', 4));
+    else if (bps > 1e3)
+        averageBitsPerSec->setText(tr("%L1 Kbps").arg(bps/1e3, 0, 'f', 4));
+    else
+        averageBitsPerSec->setText(tr("%L1 bps").arg(bps, 0, 'f', 4));
+
     averageLoadPercent->setValue(
             plm->port(currentPortIndex_).averageLoadRate()*100);
-    averagePacketsPerSec->setText(QString("%L1")
-            .arg(plm->port(currentPortIndex_).averagePacketRate(), 0, 'f', 4));
-    averageBitsPerSec->setText(QString("%L1")
-            .arg(plm->port(currentPortIndex_).averageBitRate(), 0, 'f', 0));
 }
 
 void PortWidget::updatePortActions()

--- a/client/portwidget.h
+++ b/client/portwidget.h
@@ -17,23 +17,21 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-#ifndef _STREAMS_WIDGET_H
-#define _STREAMS_WIDGET_H
+#ifndef _PORT_WIDGET_H
+#define _PORT_WIDGET_H
 
-#include "ui_streamswidget.h"
+#include "ui_portwidget.h"
 #include <QWidget>
-//#include <QAbstractItemModel>
 
 class PortGroupList;
-class QAbstractItemDelegate;
 
-class StreamsWidget : public QWidget, private Ui::StreamsWidget
+class PortWidget : public QWidget, private Ui::PortWidget
 {
     Q_OBJECT
 
 public:
-    StreamsWidget(QWidget *parent = 0);
-    ~StreamsWidget();
+    PortWidget(QWidget *parent = 0);
+    ~PortWidget();
 
     void setPortGroupList(PortGroupList *portGroups);
 
@@ -41,30 +39,19 @@ public slots:
     void setCurrentPortIndex(const QModelIndex &portIndex);
 
 private slots:
-    void updateStreamViewActions();
+
 
     void on_startTx_clicked();
     void on_stopTx_clicked();
     void on_averagePacketsPerSec_editingFinished();
     void on_averageBitsPerSec_editingFinished();
+
+    void updatePortActions();
     void updatePortRates();
-    void on_tvStreamList_activated(const QModelIndex & index);
-
-    void on_actionNew_Stream_triggered();
-    void on_actionEdit_Stream_triggered();
-    void on_actionDuplicate_Stream_triggered();
-    void on_actionDelete_Stream_triggered();
-
-    void on_actionOpen_Streams_triggered();
-    void on_actionSave_Streams_triggered();
-
-    void streamModelDataChanged();
-
+    
 private:
     PortGroupList *plm{nullptr}; // FIXME: rename to portGroups_?
     QModelIndex currentPortIndex_;
-
-    QAbstractItemDelegate *delegate;
 };
 
 #endif

--- a/client/portwidget.h
+++ b/client/portwidget.h
@@ -1,0 +1,71 @@
+/*
+Copyright (C) 2010 Srivats P.
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#ifndef _STREAMS_WIDGET_H
+#define _STREAMS_WIDGET_H
+
+#include "ui_streamswidget.h"
+#include <QWidget>
+//#include <QAbstractItemModel>
+
+class PortGroupList;
+class QAbstractItemDelegate;
+
+class StreamsWidget : public QWidget, private Ui::StreamsWidget
+{
+    Q_OBJECT
+
+public:
+    StreamsWidget(QWidget *parent = 0);
+    ~StreamsWidget();
+
+    void setPortGroupList(PortGroupList *portGroups);
+
+public slots:
+    void setCurrentPortIndex(const QModelIndex &portIndex);
+
+private slots:
+    void updateStreamViewActions();
+
+    void on_startTx_clicked();
+    void on_stopTx_clicked();
+    void on_averagePacketsPerSec_editingFinished();
+    void on_averageBitsPerSec_editingFinished();
+    void updatePortRates();
+    void on_tvStreamList_activated(const QModelIndex & index);
+
+    void on_actionNew_Stream_triggered();
+    void on_actionEdit_Stream_triggered();
+    void on_actionDuplicate_Stream_triggered();
+    void on_actionDelete_Stream_triggered();
+
+    void on_actionOpen_Streams_triggered();
+    void on_actionSave_Streams_triggered();
+
+    void streamModelDataChanged();
+
+private:
+    PortGroupList *plm{nullptr}; // FIXME: rename to portGroups_?
+    QModelIndex currentPortIndex_;
+
+    QAbstractItemDelegate *delegate;
+};
+
+#endif
+

--- a/client/portwidget.h
+++ b/client/portwidget.h
@@ -21,6 +21,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #define _PORT_WIDGET_H
 
 #include "ui_portwidget.h"
+#include <QModelIndex>
 #include <QWidget>
 
 class PortGroupList;

--- a/client/portwidget.h
+++ b/client/portwidget.h
@@ -43,6 +43,7 @@ private slots:
 
     void on_startTx_clicked();
     void on_stopTx_clicked();
+    void on_averageLoadPercent_editingFinished();
     void on_averagePacketsPerSec_editingFinished();
     void on_averageBitsPerSec_editingFinished();
 

--- a/client/portwidget.ui
+++ b/client/portwidget.ui
@@ -121,11 +121,17 @@
        <property name="enabled">
         <bool>false</bool>
        </property>
+       <property name="buttonSymbols">
+        <enum>QAbstractSpinBox::NoButtons</enum>
+       </property>
        <property name="suffix">
         <string>%</string>
        </property>
        <property name="decimals">
         <number>4</number>
+       </property>
+       <property name="maximum">
+        <double>999.999900000000025</double>
        </property>
       </widget>
      </item>

--- a/client/portwidget.ui
+++ b/client/portwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>532</width>
-    <height>42</height>
+    <width>806</width>
+    <height>73</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -76,6 +76,13 @@
       </spacer>
      </item>
      <item>
+      <widget class="Line" name="rateSep">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QRadioButton" name="radioButton">
        <property name="text">
         <string>Avg pps</string>
@@ -102,6 +109,46 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QRadioButton" name="rbLoad">
+       <property name="text">
+        <string>Load</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="averageLoadPercent">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="suffix">
+        <string>%</string>
+       </property>
+       <property name="decimals">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="speedSep">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="portSpeed">
+       <property name="toolTip">
+        <string>Port Speed</string>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Max speed</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -117,12 +164,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>326</x>
-     <y>80</y>
+     <x>450</x>
+     <y>44</y>
     </hint>
     <hint type="destinationlabel">
-     <x>454</x>
-     <y>79</y>
+     <x>593</x>
+     <y>45</y>
     </hint>
    </hints>
   </connection>
@@ -133,12 +180,28 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>523</x>
-     <y>80</y>
+     <x>661</x>
+     <y>44</y>
     </hint>
     <hint type="destinationlabel">
-     <x>651</x>
-     <y>88</y>
+     <x>804</x>
+     <y>45</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>rbLoad</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>averageLoadPercent</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>281</x>
+     <y>43</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>308</x>
+     <y>45</y>
     </hint>
    </hints>
   </connection>

--- a/client/portwidget.ui
+++ b/client/portwidget.ui
@@ -85,7 +85,7 @@
      <item>
       <widget class="QRadioButton" name="radioButton">
        <property name="text">
-        <string>Avg pps</string>
+        <string>Frame Rate</string>
        </property>
        <property name="checked">
         <bool>true</bool>
@@ -98,7 +98,7 @@
      <item>
       <widget class="QRadioButton" name="radioButton_2">
        <property name="text">
-        <string>Avg bps</string>
+        <string>Bit Rate</string>
        </property>
       </widget>
      </item>
@@ -106,6 +106,9 @@
       <widget class="QLineEdit" name="averageBitsPerSec">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Bit rate on the line including overhead such as Preamble, IPG, FCS etc.</string>
        </property>
       </widget>
      </item>

--- a/client/portwidget.ui
+++ b/client/portwidget.ui
@@ -1,19 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>StreamsWidget</class>
- <widget class="QWidget" name="StreamsWidget">
+ <class>PortWidget</class>
+ <widget class="QWidget" name="PortWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>602</width>
-    <height>364</height>
+    <width>532</width>
+    <height>42</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <layout class="QHBoxLayout">
      <item>
@@ -92,93 +104,8 @@
      </item>
     </layout>
    </item>
-   <item>
-    <widget class="XTableView" name="tvStreamList">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::ActionsContextMenu</enum>
-     </property>
-     <property name="whatsThis">
-      <string>This is the stream list for the selected port
-
-A stream is a sequence of one or more packets
-
-Right-click to create a stream</string>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="lineWidth">
-      <number>1</number>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-    </widget>
-   </item>
   </layout>
-  <action name="actionNew_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_add.png</normaloff>:/icons/stream_add.png</iconset>
-   </property>
-   <property name="text">
-    <string>New Stream</string>
-   </property>
-  </action>
-  <action name="actionDelete_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_delete.png</normaloff>:/icons/stream_delete.png</iconset>
-   </property>
-   <property name="text">
-    <string>Delete Stream</string>
-   </property>
-  </action>
-  <action name="actionEdit_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_edit.png</normaloff>:/icons/stream_edit.png</iconset>
-   </property>
-   <property name="text">
-    <string>Edit Stream</string>
-   </property>
-  </action>
-  <action name="actionOpen_Streams">
-   <property name="text">
-    <string>Open Streams ...</string>
-   </property>
-  </action>
-  <action name="actionSave_Streams">
-   <property name="text">
-    <string>Save Streams ...</string>
-   </property>
-  </action>
-  <action name="actionDuplicate_Stream">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/stream_duplicate.png</normaloff>:/icons/stream_duplicate.png</iconset>
-   </property>
-   <property name="text">
-    <string>Duplicate Stream</string>
-   </property>
-  </action>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>XTableView</class>
-   <extends>QTableView</extends>
-   <header>xtableview.h</header>
-  </customwidget>
- </customwidgets>
  <resources>
   <include location="ostinato.qrc"/>
  </resources>

--- a/client/portwidget.ui
+++ b/client/portwidget.ui
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>StreamsWidget</class>
+ <widget class="QWidget" name="StreamsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>602</width>
+    <height>364</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QToolButton" name="startTx">
+       <property name="toolTip">
+        <string>Start Transmit</string>
+       </property>
+       <property name="statusTip">
+        <string>Start transmit on selected port</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="ostinato.qrc">
+         <normaloff>:/icons/control_play.png</normaloff>:/icons/control_play.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="stopTx">
+       <property name="toolTip">
+        <string>Stop Transmit</string>
+       </property>
+       <property name="statusTip">
+        <string>Stop transmit on selected port</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="ostinato.qrc">
+         <normaloff>:/icons/control_stop.png</normaloff>:/icons/control_stop.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioButton">
+       <property name="text">
+        <string>Avg pps</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="averagePacketsPerSec"/>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioButton_2">
+       <property name="text">
+        <string>Avg bps</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="averageBitsPerSec">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="XTableView" name="tvStreamList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="contextMenuPolicy">
+      <enum>Qt::ActionsContextMenu</enum>
+     </property>
+     <property name="whatsThis">
+      <string>This is the stream list for the selected port
+
+A stream is a sequence of one or more packets
+
+Right-click to create a stream</string>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+  <action name="actionNew_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_add.png</normaloff>:/icons/stream_add.png</iconset>
+   </property>
+   <property name="text">
+    <string>New Stream</string>
+   </property>
+  </action>
+  <action name="actionDelete_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_delete.png</normaloff>:/icons/stream_delete.png</iconset>
+   </property>
+   <property name="text">
+    <string>Delete Stream</string>
+   </property>
+  </action>
+  <action name="actionEdit_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_edit.png</normaloff>:/icons/stream_edit.png</iconset>
+   </property>
+   <property name="text">
+    <string>Edit Stream</string>
+   </property>
+  </action>
+  <action name="actionOpen_Streams">
+   <property name="text">
+    <string>Open Streams ...</string>
+   </property>
+  </action>
+  <action name="actionSave_Streams">
+   <property name="text">
+    <string>Save Streams ...</string>
+   </property>
+  </action>
+  <action name="actionDuplicate_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_duplicate.png</normaloff>:/icons/stream_duplicate.png</iconset>
+   </property>
+   <property name="text">
+    <string>Duplicate Stream</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>XTableView</class>
+   <extends>QTableView</extends>
+   <header>xtableview.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="ostinato.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>radioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>averagePacketsPerSec</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>326</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>454</x>
+     <y>79</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>radioButton_2</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>averageBitsPerSec</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>523</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>651</x>
+     <y>88</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/client/streamswidget.cpp
+++ b/client/streamswidget.cpp
@@ -1,0 +1,1096 @@
+/*
+Copyright (C) 2010 Srivats P.
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#include "portswindow.h"
+
+#include "applymsg.h"
+#include "clipboardhelper.h"
+#include "deviceswidget.h"
+#include "portconfigdialog.h"
+#include "settings.h"
+#include "streamconfigdialog.h"
+#include "streamfileformat.h"
+#include "streamlistdelegate.h"
+
+#include "fileformat.pb.h"
+
+#include "xqlocale.h"
+
+#include <QFileInfo>
+#include <QInputDialog>
+#include <QItemSelectionModel>
+#include <QMainWindow>
+#include <QMessageBox>
+#include <QSortFilterProxyModel>
+
+extern ClipboardHelper *clipboardHelper;
+extern QMainWindow *mainWindow;
+
+PortsWindow::PortsWindow(PortGroupList *pgl, QWidget *parent)
+    : QWidget(parent), proxyPortModel(NULL)
+{
+    QAction *sep;
+
+    delegate = new StreamListDelegate;
+    proxyPortModel = new QSortFilterProxyModel(this);
+
+    //slm = new StreamListModel();
+    //plm = new PortGroupList();
+    plm = pgl;
+
+    Ui::PortsWindow::setupUi(this);
+    Ui::StreamsWidget::setupUi(streamsWidget);
+    applyMsg_ = new ApplyMessage();
+    devicesWidget->setPortGroupList(plm);
+
+    tvPortList->header()->hide();
+
+    tvStreamList->setItemDelegate(delegate);
+
+    tvStreamList->verticalHeader()->setDefaultSectionSize(
+            tvStreamList->verticalHeader()->minimumSectionSize());
+
+    // Populate PortList Context Menu Actions
+    tvPortList->addAction(actionNew_Port_Group);
+    tvPortList->addAction(actionDelete_Port_Group);
+    tvPortList->addAction(actionConnect_Port_Group);
+    tvPortList->addAction(actionDisconnect_Port_Group);
+
+    tvPortList->addAction(actionExclusive_Control);
+    tvPortList->addAction(actionPort_Configuration);
+
+    // Populate StreamList Context Menu Actions
+    tvStreamList->addAction(actionNew_Stream);
+    tvStreamList->addAction(actionEdit_Stream);
+    tvStreamList->addAction(actionDuplicate_Stream);
+    tvStreamList->addAction(actionDelete_Stream);
+
+    QAction *sep2 = new QAction(this);
+    sep2->setSeparator(true);
+    tvStreamList->addAction(sep2);
+
+    tvStreamList->addAction(actionOpen_Streams);
+    tvStreamList->addAction(actionSave_Streams);
+
+    // PortList, StreamList, DeviceWidget actions combined
+    // make this window's actions
+    addActions(tvPortList->actions());
+    sep = new QAction(this);
+    sep->setSeparator(true);
+    addAction(sep);
+    addActions(tvStreamList->actions());
+    sep = new QAction(this);
+    sep->setSeparator(true);
+    addAction(sep);
+    addActions(devicesWidget->actions());
+
+    // Add the clipboard actions to the context menu of streamList
+    // but not to PortsWindow's actions since they are already available
+    // in the global Edit Menu
+    sep = new QAction("Clipboard", this);
+    sep->setSeparator(true);
+    tvStreamList->insertAction(sep2, sep);
+    tvStreamList->insertActions(sep2, clipboardHelper->actions());
+
+    tvStreamList->setModel(plm->getStreamModel());
+
+    // XXX: It would be ideal if we only needed to do the below to 
+    // get the proxy model to do its magic. However, the QModelIndex
+    // used by the source model and the proxy model are different
+    // i.e. the row, column, internalId/internalPtr used by both
+    // will be different. Since our domain objects - PortGroupList,
+    // PortGroup, Port etc. use these attributes, we need to map the
+    // proxy's index to the source's index before invoking any domain
+    // object methods
+    // TODO: research if we can skip the mapping when the domain 
+    // objects' design is reviewed
+    if (proxyPortModel) {
+        proxyPortModel->setSourceModel(plm->getPortModel());
+        tvPortList->setModel(proxyPortModel);
+    }
+    else
+        tvPortList->setModel(plm->getPortModel());
+    
+    connect( plm->getPortModel(), 
+        SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)), 
+        this, SLOT(when_portModel_dataChanged(const QModelIndex&, 
+            const QModelIndex&)));
+
+    connect(plm->getPortModel(), SIGNAL(modelReset()), 
+        SLOT(when_portModel_reset()));
+
+    connect( tvPortList->selectionModel(), 
+        SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), 
+        this, SLOT(when_portView_currentChanged(const QModelIndex&, 
+            const QModelIndex&)));
+    connect(this,
+            SIGNAL(currentPortChanged(const QModelIndex&, const QModelIndex&)),
+            devicesWidget, SLOT(setCurrentPortIndex(const QModelIndex&)));
+
+    connect(plm->getStreamModel(), SIGNAL(rowsInserted(QModelIndex, int, int)), 
+        SLOT(updateStreamViewActions()));
+    connect(plm->getStreamModel(), SIGNAL(rowsRemoved(QModelIndex, int, int)), 
+        SLOT(updateStreamViewActions()));
+
+    connect(tvStreamList->selectionModel(), 
+        SIGNAL(currentChanged(const QModelIndex&, const QModelIndex&)), 
+        SLOT(updateStreamViewActions()));
+    connect(tvStreamList->selectionModel(), 
+        SIGNAL(selectionChanged(const QItemSelection&, const QItemSelection&)),
+        SLOT(updateStreamViewActions()));
+
+    tvStreamList->resizeColumnToContents(StreamModel::StreamIcon);
+    tvStreamList->resizeColumnToContents(StreamModel::StreamStatus);
+
+    // Initially we don't have any ports/streams/devices
+    //  - so send signal triggers
+    when_portView_currentChanged(QModelIndex(), QModelIndex());
+    updateStreamViewActions();
+
+    connect(plm->getStreamModel(), 
+        SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)), 
+        this, SLOT(streamModelDataChanged()));
+    connect(plm->getStreamModel(), 
+        SIGNAL(modelReset()), 
+        this, SLOT(streamModelDataChanged()));
+}
+
+void PortsWindow::streamModelDataChanged()
+{
+    QModelIndex current = tvPortList->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (plm->isPort(current))
+        plm->port(current).recalculateAverageRates();
+}
+
+PortsWindow::~PortsWindow()
+{
+    delete delegate;
+    delete proxyPortModel;
+    delete applyMsg_;
+}
+
+int PortsWindow::portGroupCount()
+{
+    return plm->numPortGroups();
+}
+
+int PortsWindow::reservedPortCount()
+{
+    int count = 0;
+    int n = portGroupCount();
+
+    for (int i = 0; i < n; i++)
+        count += plm->portGroupByIndex(i).numReservedPorts();
+
+    return count;
+}
+
+//! Always return true
+bool PortsWindow::openSession(
+        const OstProto::SessionContent *session,
+        QString & /*error*/)
+{
+    QProgressDialog progress("Opening Session", NULL,
+                             0, session->port_groups_size(), mainWindow);
+    progress.show();
+    progress.setEnabled(true); // since parent (mainWindow) is disabled
+
+    plm->removeAllPortGroups();
+
+    for (int i = 0; i < session->port_groups_size(); i++) {
+        const OstProto::PortGroupContent &pgc = session->port_groups(i);
+        PortGroup *pg = new PortGroup(QString::fromStdString(
+                                                    pgc.server_name()),
+                                      quint16(pgc.server_port()));
+        pg->setConfigAtConnect(&pgc);
+        plm->addPortGroup(*pg);
+        progress.setValue(i+1);
+    }
+
+    return true;
+}
+
+/*!
+ * Prepare content to be saved for a session
+ *
+ * If port reservation is in use, saves only 'my' reserved ports
+ *
+ * Returns false, if user cancels op; true, otherwise
+ */
+bool PortsWindow::saveSession(
+        OstProto::SessionContent *session, // OUT param
+        QString & /*error*/,
+        QProgressDialog *progress)
+{
+    int n = portGroupCount();
+    QString myself;
+
+    if (progress) {
+        progress->setLabelText("Preparing Ports and PortGroups ...");
+        progress->setRange(0, n);
+    }
+
+    if (reservedPortCount())
+        myself = appSettings->value(kUserKey, kUserDefaultValue).toString();
+
+    for (int i = 0; i < n; i++)
+    {
+        PortGroup &pg = plm->portGroupByIndex(i);
+        OstProto::PortGroupContent *pgc = session->add_port_groups();
+
+        pgc->set_server_name(pg.serverName().toStdString());
+        pgc->set_server_port(pg.serverPort());
+
+        for (int j = 0; j < pg.numPorts(); j++)
+        {
+            if (myself != pg.mPorts.at(j)->userName())
+                continue;
+
+            OstProto::PortContent *pc = pgc->add_ports();
+            OstProto::Port *p = pc->mutable_port_config();
+
+            // XXX: We save the entire OstProto::Port even though some
+            // fields may be ephemeral; while opening we use only relevant
+            // fields
+            pg.mPorts.at(j)->protoDataCopyInto(p);
+
+            for (int k = 0; k < pg.mPorts.at(j)->numStreams(); k++)
+            {
+                OstProto::Stream *s = pc->add_streams();
+                pg.mPorts.at(j)->streamByIndex(k)->protoDataCopyInto(*s);
+            }
+
+            for (int k = 0; k < pg.mPorts.at(j)->numDeviceGroups(); k++)
+            {
+                OstProto::DeviceGroup *dg = pc->add_device_groups();
+                dg->CopyFrom(*(pg.mPorts.at(j)->deviceGroupByIndex(k)));
+            }
+        }
+
+        if (progress) {
+            if (progress->wasCanceled())
+                return false;
+            progress->setValue(i);
+        }
+        if (i % 2 == 0)
+            qApp->processEvents();
+    }
+
+    return true;
+}
+
+void PortsWindow::clearCurrentSelection()
+{
+    tvPortList->selectionModel()->clearCurrentIndex();
+    tvPortList->clearSelection();
+}
+
+void PortsWindow::showMyReservedPortsOnly(bool enabled)
+{
+    if (!proxyPortModel)
+        return;
+
+    if (enabled) {
+        QString rx = "Port Group|\\["
+                    + QRegExp::escape(appSettings->value(kUserKey, 
+                                            kUserDefaultValue).toString())
+                    + "\\]";
+        qDebug("%s: regexp: <%s>", __FUNCTION__, qPrintable(rx));
+        proxyPortModel->setFilterRegExp(QRegExp(rx));
+    }
+    else
+        proxyPortModel->setFilterRegExp(QRegExp(""));
+}
+
+void PortsWindow::on_tvStreamList_activated(const QModelIndex & index)
+{
+    if (!index.isValid())
+    {
+        qDebug("%s: invalid index", __FUNCTION__);
+        return;
+    }
+
+    qDebug("stream list activated\n");
+
+    Port &curPort = plm->port(proxyPortModel ?
+        proxyPortModel->mapToSource(tvPortList->currentIndex()) :
+        tvPortList->currentIndex());
+
+    QList<Stream*> streams;
+    streams.append(curPort.mutableStreamByIndex(index.row(), false));
+
+    StreamConfigDialog scd(streams, curPort, this);
+    if (scd.exec() == QDialog::Accepted) {
+        curPort.recalculateAverageRates();
+        curPort.setLocalConfigChanged(true);
+    }
+}
+
+void PortsWindow::when_portView_currentChanged(const QModelIndex& currentIndex,
+    const QModelIndex& previousIndex)
+{
+    QModelIndex current = currentIndex;
+    QModelIndex previous = previousIndex;
+
+    if (proxyPortModel) {
+        current = proxyPortModel->mapToSource(current);
+        previous = proxyPortModel->mapToSource(previous);
+    }
+
+    plm->getStreamModel()->setCurrentPortIndex(current);
+    updatePortViewActions(currentIndex);
+    updateStreamViewActions();
+
+    qDebug("In %s", __FUNCTION__);
+
+    if (previous.isValid() && plm->isPort(previous))
+    {
+        disconnect(&(plm->port(previous)), SIGNAL(portRateChanged(int, int)),
+                this, SLOT(updatePortRates()));
+        disconnect(&(plm->port(previous)),
+                   SIGNAL(localConfigChanged(int, int, bool)),
+                   this,
+                   SLOT(updateApplyHint(int, int, bool)));
+    }
+
+    if (!current.isValid())
+    {    
+        qDebug("setting stacked widget to welcome page");
+        swDetail->setCurrentIndex(0); // welcome page
+    }
+    else
+    {
+        if (plm->isPortGroup(current))
+        {
+            swDetail->setCurrentIndex(1);    // portGroup detail page    
+        }
+        else if (plm->isPort(current))
+        {
+            swDetail->setCurrentIndex(2);    // port detail page
+            updatePortRates();
+            connect(&(plm->port(current)), SIGNAL(portRateChanged(int, int)),
+                    SLOT(updatePortRates()));
+            connect(&(plm->port(current)),
+                    SIGNAL(localConfigChanged(int, int, bool)),
+                    SLOT(updateApplyHint(int, int, bool)));
+            if (plm->port(current).isDirty())
+                updateApplyHint(plm->port(current).portGroupId(),
+                                plm->port(current).id(), true);
+            else if (plm->port(current).numStreams())
+                applyHint->setText("Click <img src=':/icons/control_play'/> "
+                                   "to transmit packets");
+            else
+                applyHint->setText("");
+        }
+    }
+
+    emit currentPortChanged(current, previous);
+}
+
+void PortsWindow::when_portModel_dataChanged(const QModelIndex& topLeft,
+    const QModelIndex& bottomRight)
+{
+    qDebug("In %s %d:(%d, %d) - %d:(%d, %d)", __FUNCTION__,
+            topLeft.parent().isValid(), topLeft.row(), topLeft.column(),
+            bottomRight.parent().isValid(), bottomRight.row(), bottomRight.column());
+
+    if (!topLeft.isValid() || !bottomRight.isValid())
+        return;
+
+    if (topLeft.parent() != bottomRight.parent())
+        return;
+
+    // If a port has changed, expand the port group
+    if (topLeft.parent().isValid())
+        tvPortList->expand(proxyPortModel ? 
+                proxyPortModel->mapFromSource(topLeft.parent()) : 
+                topLeft.parent());
+
+#if 0 // not sure why the >= <= operators are not overloaded in QModelIndex
+    if ((tvPortList->currentIndex() >= topLeft) &&
+        (tvPortList->currentIndex() <= bottomRight))
+#endif
+    if (((topLeft < tvPortList->currentIndex()) || 
+            (topLeft == tvPortList->currentIndex())) &&
+        (((tvPortList->currentIndex() < bottomRight)) || 
+            (tvPortList->currentIndex() == bottomRight)))
+    {
+        // Update UI to reflect potential change in exclusive mode,
+        // transmit mode et al
+        when_portView_currentChanged(tvPortList->currentIndex(),
+                tvPortList->currentIndex());
+    }
+}
+
+void PortsWindow::when_portModel_reset()
+{
+    when_portView_currentChanged(QModelIndex(), tvPortList->currentIndex());
+}
+
+void PortsWindow::on_startTx_clicked()
+{
+    QModelIndex current = tvPortList->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    Q_ASSERT(plm->isPort(current));
+
+    QModelIndex curPortGroup = plm->getPortModel()->parent(current);
+    Q_ASSERT(curPortGroup.isValid());
+    Q_ASSERT(plm->isPortGroup(curPortGroup));
+
+    QList<uint> portList({plm->port(current).id()});
+    plm->portGroup(curPortGroup).startTx(&portList);
+}
+
+void PortsWindow::on_stopTx_clicked()
+{
+    QModelIndex current = tvPortList->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    Q_ASSERT(plm->isPort(current));
+
+    QModelIndex curPortGroup = plm->getPortModel()->parent(current);
+    Q_ASSERT(curPortGroup.isValid());
+    Q_ASSERT(plm->isPortGroup(curPortGroup));
+
+    QList<uint> portList({plm->port(current).id()});
+    plm->portGroup(curPortGroup).stopTx(&portList);
+}
+
+void PortsWindow::on_averagePacketsPerSec_editingFinished()
+{
+    QModelIndex current = tvPortList->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    Q_ASSERT(plm->isPort(current));
+
+    bool isOk;
+    double pps = XLocale().toDouble(averagePacketsPerSec->text(), &isOk);
+
+    plm->port(current).setAveragePacketRate(pps);
+}
+
+void PortsWindow::on_averageBitsPerSec_editingFinished()
+{
+    QModelIndex current = tvPortList->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    Q_ASSERT(plm->isPort(current));
+
+    bool isOk;
+    double bps = XLocale().toDouble(averageBitsPerSec->text(), &isOk);
+
+    plm->port(current).setAverageBitRate(bps);
+}
+
+void PortsWindow::updatePortRates()
+{
+    QModelIndex current = tvPortList->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (!current.isValid())
+        return;
+
+    if (!plm->isPort(current))
+        return;
+
+    averagePacketsPerSec->setText(QString("%L1")
+            .arg(plm->port(current).averagePacketRate(), 0, 'f', 4));
+    averageBitsPerSec->setText(QString("%L1")
+            .arg(plm->port(current).averageBitRate(), 0, 'f', 0));
+}
+
+void PortsWindow::updateStreamViewActions()
+{
+    QModelIndex current = tvPortList->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    // For some reason hasSelection() returns true even if selection size is 0
+    // so additional check for size introduced
+    if (tvStreamList->selectionModel()->hasSelection() &&
+        (tvStreamList->selectionModel()->selection().size() > 0))
+    {
+        qDebug("Has selection %d",
+            tvStreamList->selectionModel()->selection().size());
+
+        // If more than one non-contiguous ranges selected,
+        // disable "New" and "Edit"
+        if (tvStreamList->selectionModel()->selection().size() > 1)
+        {
+            actionNew_Stream->setDisabled(true);
+            actionEdit_Stream->setDisabled(true);
+        }
+        else
+        {
+            actionNew_Stream->setEnabled(true);
+            actionEdit_Stream->setEnabled(true);
+        }
+
+        // Duplicate/Delete are always enabled as long as we have a selection
+        actionDuplicate_Stream->setEnabled(true);
+        actionDelete_Stream->setEnabled(true);
+    }
+    else
+    {
+        qDebug("No selection");
+        if (plm->isPort(current))
+            actionNew_Stream->setEnabled(true);
+        else
+            actionNew_Stream->setDisabled(true);
+        actionEdit_Stream->setDisabled(true);
+        actionDuplicate_Stream->setDisabled(true);
+        actionDelete_Stream->setDisabled(true);
+    }
+    actionOpen_Streams->setEnabled(plm->isPort(current));
+    actionSave_Streams->setEnabled(tvStreamList->model()->rowCount() > 0);
+
+    startTx->setEnabled(tvStreamList->model()->rowCount() > 0);
+    stopTx->setEnabled(tvStreamList->model()->rowCount() > 0);
+}
+
+void PortsWindow::updateApplyHint(int /*portGroupId*/, int /*portId*/,
+        bool configChanged)
+{
+    if (configChanged)
+        applyHint->setText("Configuration has changed - "
+                           "<font color='red'><b>click Apply</b></font> "
+                           "to activate the changes");
+    else if (tvStreamList->model()->rowCount() > 0)
+        applyHint->setText("Configuration activated - "
+                           "click <img src=':/icons/control_play'/> "
+                           "to transmit packets");
+    else
+        applyHint->setText("Configuration activated");
+}
+
+void PortsWindow::updatePortViewActions(const QModelIndex& currentIndex)
+{
+    QModelIndex current = currentIndex;
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (!current.isValid())
+    {
+        qDebug("current is now invalid");
+        actionDelete_Port_Group->setDisabled(true);
+        actionConnect_Port_Group->setDisabled(true);
+        actionDisconnect_Port_Group->setDisabled(true);
+
+        actionExclusive_Control->setDisabled(true);
+        actionPort_Configuration->setDisabled(true);
+    
+        goto _EXIT;
+    }
+
+    qDebug("currentChanged %p", (void*)current.internalId());
+
+    if (plm->isPortGroup(current))
+    {
+        actionDelete_Port_Group->setEnabled(true);
+
+        actionExclusive_Control->setDisabled(true);
+        actionPort_Configuration->setDisabled(true);
+
+        switch(plm->portGroup(current).state())
+        {
+            case QAbstractSocket::UnconnectedState:
+            case QAbstractSocket::ClosingState:
+                qDebug("state = unconnected|closing");
+                actionConnect_Port_Group->setEnabled(true);
+                actionDisconnect_Port_Group->setDisabled(true);
+                break;
+
+            case QAbstractSocket::HostLookupState:
+            case QAbstractSocket::ConnectingState:
+            case QAbstractSocket::ConnectedState:
+                qDebug("state = lookup|connecting|connected");
+                actionConnect_Port_Group->setDisabled(true);
+                actionDisconnect_Port_Group->setEnabled(true);
+                break;
+
+
+            case QAbstractSocket::BoundState:
+            case QAbstractSocket::ListeningState:
+            default:
+                // FIXME(LOW): indicate error
+                qDebug("unexpected state");
+                break;
+        }
+    }
+    else if (plm->isPort(current))
+    {
+        actionDelete_Port_Group->setDisabled(true);
+        actionConnect_Port_Group->setDisabled(true);
+        actionDisconnect_Port_Group->setDisabled(true);
+
+        actionExclusive_Control->setEnabled(true);
+        if (plm->port(current).hasExclusiveControl())
+            actionExclusive_Control->setChecked(true);
+        else
+            actionExclusive_Control->setChecked(false);
+        actionPort_Configuration->setEnabled(true);
+    }
+
+_EXIT:
+    return;
+}
+
+void PortsWindow::on_pbApply_clicked()
+{
+    QModelIndex    curPort;
+    QModelIndex curPortGroup;
+
+    curPort = tvPortList->selectionModel()->currentIndex();
+    if (proxyPortModel)
+        curPort = proxyPortModel->mapToSource(curPort);
+    if (!curPort.isValid())
+    {
+        qDebug("%s: curPort is invalid", __FUNCTION__);
+        goto _exit;
+    }
+
+    if (!plm->isPort(curPort))
+    {
+        qDebug("%s: curPort is not a port", __FUNCTION__);
+        goto _exit;
+    }
+
+    if (plm->port(curPort).getStats().state().is_transmit_on())
+    {
+        QMessageBox::information(0, "Configuration Change",
+                "Please stop transmit on the port before applying any changes");
+        goto _exit;
+    }
+
+    curPortGroup = plm->getPortModel()->parent(curPort);
+    if (!curPortGroup.isValid())
+    {
+        qDebug("%s: curPortGroup is invalid", __FUNCTION__);
+        goto _exit;
+    }
+    if (!plm->isPortGroup(curPortGroup))
+    {
+        qDebug("%s: curPortGroup is not a portGroup", __FUNCTION__);
+        goto _exit;
+    }
+
+    disconnect(applyMsg_);
+    connect(&(plm->portGroup(curPortGroup)), SIGNAL(applyFinished()),
+            applyMsg_, SLOT(hide()));
+    applyMsg_->show();
+
+    // FIXME(HI): shd this be a signal?
+    //portGroup.when_configApply(port);
+    // FIXME(MED): mixing port id and index!!!
+    plm->portGroup(curPortGroup).when_configApply(plm->port(curPort).id());
+
+_exit:
+    return;
+
+#if 0
+    // TODO (LOW): This block is for testing only
+    QModelIndex    current = tvPortList->selectionModel()->currentIndex();
+
+    if (current.isValid())
+        qDebug("current =  %llx", current.internalId());
+    else
+        qDebug("current is invalid");
+#endif
+}
+
+void PortsWindow::on_actionNew_Port_Group_triggered()
+{
+    bool ok;
+    QString text = QInputDialog::getText(this, 
+        "Add Port Group", "Port Group Address (HostName[:Port])",
+        QLineEdit::Normal, lastNewPortGroup, &ok);
+    
+    if (ok)
+    {
+        QStringList addr = text.split(":");
+        quint16 port = DEFAULT_SERVER_PORT;
+
+        if (addr.size() > 2) { // IPv6 Address
+            // IPv6 addresses with port number SHOULD be specified as
+            // [2001:db8::1]:80 (RFC5952 Sec6) to avoid ambiguity due to ':'
+            addr = text.split("]:");
+            if (addr.size() > 1)
+                port = addr[1].toUShort();
+        }
+        else if (addr.size() == 2) // Hostname/IPv4 + Port specified
+            port = addr[1].toUShort();
+
+        // Play nice and remove square brackets irrespective of addr type
+        addr[0].remove(QChar('['));
+        addr[0].remove(QChar(']'));
+
+        PortGroup *pg = new PortGroup(addr[0], port);
+        plm->addPortGroup(*pg);
+        lastNewPortGroup = text;
+    }
+}
+
+void PortsWindow::on_actionDelete_Port_Group_triggered()
+{
+    QModelIndex    current = tvPortList->selectionModel()->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (current.isValid())
+        plm->removePortGroup(plm->portGroup(current));
+}
+
+void PortsWindow::on_actionConnect_Port_Group_triggered()
+{
+    QModelIndex    current = tvPortList->selectionModel()->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (current.isValid())
+        plm->portGroup(current).connectToHost();
+}
+
+void PortsWindow::on_actionDisconnect_Port_Group_triggered()
+{
+    QModelIndex    current = tvPortList->selectionModel()->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (current.isValid())
+        plm->portGroup(current).disconnectFromHost();
+}
+
+void PortsWindow::on_actionExclusive_Control_triggered(bool checked)
+{
+    QModelIndex    current = tvPortList->selectionModel()->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (plm->isPort(current))
+    {
+        OstProto::Port config;
+        
+        config.set_is_exclusive_control(checked);
+        plm->portGroup(current.parent()).modifyPort(current.row(), config);
+    }
+}
+
+void PortsWindow::on_actionPort_Configuration_triggered()
+{
+    QModelIndex    current = tvPortList->selectionModel()->currentIndex();
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (!plm->isPort(current))
+        return;
+
+    Port &port = plm->port(current);
+    OstProto::Port config;
+    // XXX: we don't call Port::protoDataCopyInto() to get config b'coz
+    // we want only the modifiable fields populated to send to Drone
+    // TODO: extend Port::protoDataCopyInto() to accept an optional param
+    // which says copy only modifiable fields
+    //plm->port(current).protoDataCopyInto(&config);
+    config.set_transmit_mode(port.transmitMode());
+    config.set_is_tracking_stream_stats(port.trackStreamStats());
+    config.set_is_exclusive_control(port.hasExclusiveControl());
+    config.set_user_name(port.userName().toStdString());
+
+    PortConfigDialog dialog(config, port.getStats().state(), this);
+
+    if (dialog.exec() == QDialog::Accepted)
+        plm->portGroup(current.parent()).modifyPort(current.row(), config);
+}
+
+void PortsWindow::on_actionNew_Stream_triggered()
+{
+    qDebug("New Stream Action");
+
+    QItemSelectionModel* selectionModel = tvStreamList->selectionModel();
+    if (selectionModel->selection().size() > 1) {
+        qDebug("%s: Unexpected selection size %d, can't add", __FUNCTION__,
+                selectionModel->selection().size());
+        return;
+    }
+
+    // In case nothing is selected, insert 1 row at the end
+    StreamModel *streamModel = plm->getStreamModel();
+    int row = streamModel->rowCount(), count = 1;
+
+    // In case we have a single range selected; insert as many rows as
+    // in the singe selected range before the top of the selected range
+    if (selectionModel->selection().size() == 1)
+    {
+        row = selectionModel->selection().at(0).top();
+        count = selectionModel->selection().at(0).height();
+    }
+
+    Port &curPort = plm->port(proxyPortModel ?
+        proxyPortModel->mapToSource(tvPortList->currentIndex()) :
+        tvPortList->currentIndex());
+
+    QList<Stream*> streams;
+    for (int i = 0; i < count; i++)
+        streams.append(new Stream);
+
+    StreamConfigDialog scd(streams, curPort, this);
+    scd.setWindowTitle(tr("Add Stream"));
+    if (scd.exec() == QDialog::Accepted)
+        streamModel->insert(row, streams);
+}
+
+void PortsWindow::on_actionEdit_Stream_triggered()
+{
+    qDebug("Edit Stream Action");
+
+    QItemSelectionModel* streamModel = tvStreamList->selectionModel();
+    if (!streamModel->hasSelection())
+        return;
+
+    Port &curPort = plm->port(proxyPortModel ?
+        proxyPortModel->mapToSource(tvPortList->currentIndex()) :
+        tvPortList->currentIndex());
+
+    QList<Stream*> streams;
+    foreach(QModelIndex index, streamModel->selectedRows())
+        streams.append(curPort.mutableStreamByIndex(index.row(), false));
+
+    StreamConfigDialog scd(streams, curPort, this);
+    if (scd.exec() == QDialog::Accepted) {
+        curPort.recalculateAverageRates();
+        curPort.setLocalConfigChanged(true);
+    }
+}
+
+void PortsWindow::on_actionDuplicate_Stream_triggered()
+{
+    QItemSelectionModel* model = tvStreamList->selectionModel();
+    QModelIndex current = tvPortList->selectionModel()->currentIndex();
+
+    qDebug("Duplicate Stream Action");
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    if (model->hasSelection())
+    {
+        bool isOk;
+        int count = QInputDialog::getInt(this, "Duplicate Streams",
+                "Count", 1, 1, 9999, 1, &isOk);
+
+        if (!isOk)
+            return;
+
+        QList<int> list;
+        foreach(QModelIndex index, model->selectedRows())
+            list.append(index.row());
+        plm->port(current).duplicateStreams(list, count);
+    }
+    else
+        qDebug("No selection");
+}
+
+void PortsWindow::on_actionDelete_Stream_triggered()
+{
+    qDebug("Delete Stream Action");
+
+    QModelIndex        index;
+
+    if (tvStreamList->selectionModel()->hasSelection())
+    {
+        qDebug("SelectedIndexes %d",
+            tvStreamList->selectionModel()->selectedRows().size());
+        while(tvStreamList->selectionModel()->selectedRows().size())
+        {
+            index = tvStreamList->selectionModel()->selectedRows().at(0);
+            plm->getStreamModel()->removeRows(index.row(), 1);    
+        }
+    }
+    else
+        qDebug("No selection");
+}
+
+void PortsWindow::on_actionOpen_Streams_triggered()
+{
+    qDebug("Open Streams Action");
+
+    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
+                                            StreamFileFormat::kOpenFile);
+    QString fileType;
+    QModelIndex current = tvPortList->selectionModel()->currentIndex();
+    static QString dirName;
+    QString fileName;
+    QString errorStr;
+    bool append = true;
+    bool ret;
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    Q_ASSERT(plm->isPort(current));
+
+    if (fileTypes.size())
+        fileType = fileTypes.at(0);
+
+    fileName = QFileDialog::getOpenFileName(this, tr("Open Streams"),
+            dirName, fileTypes.join(";;"), &fileType);
+    if (fileName.isEmpty())
+        goto _exit;
+
+    if (tvStreamList->model()->rowCount())
+    {
+        QMessageBox msgBox(QMessageBox::Question, qApp->applicationName(),
+                tr("Append to existing streams? Or overwrite?"),
+                QMessageBox::NoButton, this);
+        QPushButton *appendBtn = msgBox.addButton(tr("Append"), 
+                QMessageBox::ActionRole);
+        QPushButton *overwriteBtn = msgBox.addButton(tr("Overwrite"), 
+                QMessageBox::ActionRole);
+        QPushButton *cancelBtn = msgBox.addButton(QMessageBox::Cancel);
+
+        msgBox.exec();
+
+        if (msgBox.clickedButton() == cancelBtn)
+            goto _exit;
+        else if (msgBox.clickedButton() == appendBtn)
+            append = true;
+        else if (msgBox.clickedButton() == overwriteBtn)
+            append = false;
+        else
+            Q_ASSERT(false);
+    }
+
+    ret = plm->port(current).openStreams(fileName, append, errorStr);
+    if (!ret || !errorStr.isEmpty())
+    {
+        QMessageBox msgBox(this);
+        QStringList str = errorStr.split("\n\n\n\n");
+
+        msgBox.setIcon(ret ? QMessageBox::Warning : QMessageBox::Critical);
+        msgBox.setWindowTitle(qApp->applicationName());
+        msgBox.setText(str.at(0));
+        if (str.size() > 1)
+            msgBox.setDetailedText(str.at(1));
+        msgBox.setStandardButtons(QMessageBox::Ok);
+
+        msgBox.exec();
+    }
+    dirName = QFileInfo(fileName).absolutePath();
+
+_exit:
+    return;
+}
+
+void PortsWindow::on_actionSave_Streams_triggered()
+{
+    qDebug("Save Streams Action");
+
+    QModelIndex current = tvPortList->selectionModel()->currentIndex();
+    static QString fileName;
+    QStringList fileTypes = StreamFileFormat::supportedFileTypes(
+                                            StreamFileFormat::kSaveFile);
+    QString fileType;
+    QString errorStr;
+    QFileDialog::Options options;
+
+    if (proxyPortModel)
+        current = proxyPortModel->mapToSource(current);
+
+    // On Mac OS with Native Dialog, getSaveFileName() ignores fileType 
+    // which we need
+#if defined(Q_OS_MAC)
+    options |= QFileDialog::DontUseNativeDialog;
+#endif
+
+    if (fileTypes.size())
+        fileType = fileTypes.at(0);
+
+    Q_ASSERT(plm->isPort(current));
+
+_retry:
+    fileName = QFileDialog::getSaveFileName(this, tr("Save Streams"),
+            fileName, fileTypes.join(";;"), &fileType, options);
+    if (fileName.isEmpty())
+        goto _exit;
+
+    if (QFileInfo(fileName).suffix().isEmpty()) {
+        QString fileExt = fileType.section(QRegExp("[\\*\\)]"), 1, 1);
+        qDebug("Adding extension '%s' to '%s'",
+                qPrintable(fileExt), qPrintable(fileName));
+        fileName.append(fileExt);
+        if (QFileInfo(fileName).exists()) {
+            if (QMessageBox::warning(this, tr("Overwrite File?"), 
+                QString("The file \"%1\" already exists.\n\n"
+                    "Do you wish to overwrite it?")
+                    .arg(QFileInfo(fileName).fileName()),
+                QMessageBox::Yes|QMessageBox::No,
+                QMessageBox::No) != QMessageBox::Yes)
+                goto _retry;
+        }
+    }
+
+    fileType = fileType.remove(QRegExp("\\(.*\\)")).trimmed();
+    if (!fileType.startsWith("Ostinato") 
+            && !fileType.startsWith("Python"))
+    {
+        if (QMessageBox::warning(this, tr("Ostinato"), 
+            QString("You have chosen to save in %1 format. All stream "
+                "attributes may not be saved in this format.\n\n"
+                "It is recommended to save in native Ostinato format.\n\n"
+                "Continue to save in %2 format?").arg(fileType).arg(fileType),
+            QMessageBox::Yes|QMessageBox::No,
+            QMessageBox::No) != QMessageBox::Yes)
+            goto _retry;
+    }
+
+    // TODO: all or selected?
+
+    if (!plm->port(current).saveStreams(fileName, fileType, errorStr))
+        QMessageBox::critical(this, qApp->applicationName(), errorStr);
+    else if (!errorStr.isEmpty())
+        QMessageBox::warning(this, qApp->applicationName(), errorStr);
+
+    fileName = QFileInfo(fileName).absolutePath();
+_exit:
+    return;
+}
+
+

--- a/client/streamswidget.cpp
+++ b/client/streamswidget.cpp
@@ -24,7 +24,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "streamconfigdialog.h"
 #include "streamfileformat.h"
 #include "streamlistdelegate.h"
-#include "xqlocale.h"
 
 #include <QInputDialog>
 #include <QItemSelectionModel>
@@ -143,80 +142,10 @@ void StreamsWidget::setCurrentPortIndex(const QModelIndex &portIndex)
 
     qDebug("In %s", __FUNCTION__);
 
-    // Disconnect previous port
-    if (plm->isPort(currentPortIndex_))
-        disconnect(&(plm->port(currentPortIndex_)),
-                SIGNAL(portRateChanged(int, int)),
-                this, SLOT(updatePortRates()));
-
     currentPortIndex_ = portIndex;
     plm->getStreamModel()->setCurrentPortIndex(portIndex);
 
-    // Connect current port
-    if (plm->isPort(currentPortIndex_))
-        connect(&(plm->port(currentPortIndex_)),
-                SIGNAL(portRateChanged(int, int)),
-                this, SLOT(updatePortRates()));
-    updatePortRates();
     updateStreamViewActions();
-}
-
-void StreamsWidget::on_startTx_clicked()
-{
-    Q_ASSERT(plm->isPort(currentPortIndex_));
-
-    QModelIndex curPortGroup = plm->getPortModel()->parent(currentPortIndex_);
-    Q_ASSERT(curPortGroup.isValid());
-    Q_ASSERT(plm->isPortGroup(curPortGroup));
-
-    QList<uint> portList({plm->port(currentPortIndex_).id()});
-    plm->portGroup(curPortGroup).startTx(&portList);
-}
-
-void StreamsWidget::on_stopTx_clicked()
-{
-    Q_ASSERT(plm->isPort(currentPortIndex_));
-
-    QModelIndex curPortGroup = plm->getPortModel()->parent(currentPortIndex_);
-    Q_ASSERT(curPortGroup.isValid());
-    Q_ASSERT(plm->isPortGroup(curPortGroup));
-
-    QList<uint> portList({plm->port(currentPortIndex_).id()});
-    plm->portGroup(curPortGroup).stopTx(&portList);
-}
-
-void StreamsWidget::on_averagePacketsPerSec_editingFinished()
-{
-    Q_ASSERT(plm->isPort(currentPortIndex_));
-
-    bool isOk;
-    double pps = XLocale().toDouble(averagePacketsPerSec->text(), &isOk);
-
-    plm->port(currentPortIndex_).setAveragePacketRate(pps);
-}
-
-void StreamsWidget::on_averageBitsPerSec_editingFinished()
-{
-    Q_ASSERT(plm->isPort(currentPortIndex_));
-
-    bool isOk;
-    double bps = XLocale().toDouble(averageBitsPerSec->text(), &isOk);
-
-    plm->port(currentPortIndex_).setAverageBitRate(bps);
-}
-
-void StreamsWidget::updatePortRates()
-{
-    if (!currentPortIndex_.isValid())
-        return;
-
-    if (!plm->isPort(currentPortIndex_))
-        return;
-
-    averagePacketsPerSec->setText(QString("%L1")
-            .arg(plm->port(currentPortIndex_).averagePacketRate(), 0, 'f', 4));
-    averageBitsPerSec->setText(QString("%L1")
-            .arg(plm->port(currentPortIndex_).averageBitRate(), 0, 'f', 0));
 }
 
 void StreamsWidget::updateStreamViewActions()
@@ -259,9 +188,6 @@ void StreamsWidget::updateStreamViewActions()
     }
     actionOpen_Streams->setEnabled(plm->isPort(currentPortIndex_));
     actionSave_Streams->setEnabled(tvStreamList->model()->rowCount() > 0);
-
-    startTx->setEnabled(tvStreamList->model()->rowCount() > 0);
-    stopTx->setEnabled(tvStreamList->model()->rowCount() > 0);
 }
 
 void StreamsWidget::on_actionNew_Stream_triggered()
@@ -501,5 +427,4 @@ _retry:
 _exit:
     return;
 }
-
 

--- a/client/streamswidget.h
+++ b/client/streamswidget.h
@@ -22,7 +22,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 
 #include "ui_streamswidget.h"
 #include <QWidget>
-//#include <QAbstractItemModel>
 
 class PortGroupList;
 class QAbstractItemDelegate;
@@ -43,11 +42,6 @@ public slots:
 private slots:
     void updateStreamViewActions();
 
-    void on_startTx_clicked();
-    void on_stopTx_clicked();
-    void on_averagePacketsPerSec_editingFinished();
-    void on_averageBitsPerSec_editingFinished();
-    void updatePortRates();
     void on_tvStreamList_activated(const QModelIndex & index);
 
     void on_actionNew_Stream_triggered();

--- a/client/streamswidget.h
+++ b/client/streamswidget.h
@@ -17,61 +17,30 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-#ifndef _PORTS_WINDOW_H
-#define _PORTS_WINDOW_H
+#ifndef _STREAMS_WIDGET_H
+#define _STREAMS_WIDGET_H
 
-#include <QWidget>
-#include <QAbstractItemModel>
-#include "ui_portswindow.h"
 #include "ui_streamswidget.h"
-#include "portgrouplist.h"
+#include <QWidget>
+//#include <QAbstractItemModel>
 
-class ApplyMessage;
+class PortGroupList;
 class QAbstractItemDelegate;
-class QProgressDialog;
-class QSortFilterProxyModel;
 
-namespace OstProto {
-    class SessionContent;
-}
-
-class PortsWindow : public QWidget, private Ui::PortsWindow, private Ui::StreamsWidget
+class StreamsWidget : public QWidget, private Ui::StreamsWidget
 {
     Q_OBJECT
 
-    //QAbstractItemModel    *slm; // stream list model
-    PortGroupList        *plm;
-
 public:
-    PortsWindow(PortGroupList *pgl, QWidget *parent = 0);
-    ~PortsWindow();
+    StreamsWidget(QWidget *parent = 0);
+    ~StreamsWidget();
 
-    int portGroupCount();
-    int reservedPortCount();
-
-    bool openSession(const OstProto::SessionContent *session,
-                     QString &error);
-    bool saveSession(OstProto::SessionContent *session,
-                     QString &error,
-                     QProgressDialog *progress = NULL);
-
-signals:
-    void currentPortChanged(const QModelIndex &current,
-                            const QModelIndex &previous);
-
-private:
-    QString        lastNewPortGroup;
-    QAbstractItemDelegate *delegate;
-    QSortFilterProxyModel *proxyPortModel;
-    ApplyMessage *applyMsg_;
+    void setPortGroupList(PortGroupList *portGroups);
 
 public slots:
-    void clearCurrentSelection();
-    void showMyReservedPortsOnly(bool enabled);
+    void setCurrentPortIndex(const QModelIndex &portIndex);
 
 private slots:
-    void updateApplyHint(int portGroupId, int portId, bool configChanged);
-    void updatePortViewActions(const QModelIndex& currentIndex);
     void updateStreamViewActions();
 
     void on_startTx_clicked();
@@ -80,21 +49,6 @@ private slots:
     void on_averageBitsPerSec_editingFinished();
     void updatePortRates();
     void on_tvStreamList_activated(const QModelIndex & index);
-    void when_portView_currentChanged(const QModelIndex& currentIndex,
-        const QModelIndex& previousIndex);
-    void when_portModel_dataChanged(const QModelIndex& topLeft,
-        const QModelIndex& bottomRight);
-    void when_portModel_reset();
-
-    void on_pbApply_clicked();    
-
-    void on_actionNew_Port_Group_triggered();
-    void on_actionDelete_Port_Group_triggered();
-    void on_actionConnect_Port_Group_triggered();
-    void on_actionDisconnect_Port_Group_triggered();
-
-    void on_actionExclusive_Control_triggered(bool checked);
-    void on_actionPort_Configuration_triggered();
 
     void on_actionNew_Stream_triggered();
     void on_actionEdit_Stream_triggered();
@@ -105,6 +59,12 @@ private slots:
     void on_actionSave_Streams_triggered();
 
     void streamModelDataChanged();
+
+private:
+    PortGroupList *plm{nullptr}; // FIXME: rename to portGroups_?
+    QModelIndex currentPortIndex_;
+
+    QAbstractItemDelegate *delegate;
 };
 
 #endif

--- a/client/streamswidget.h
+++ b/client/streamswidget.h
@@ -1,0 +1,111 @@
+/*
+Copyright (C) 2010 Srivats P.
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#ifndef _PORTS_WINDOW_H
+#define _PORTS_WINDOW_H
+
+#include <QWidget>
+#include <QAbstractItemModel>
+#include "ui_portswindow.h"
+#include "ui_streamswidget.h"
+#include "portgrouplist.h"
+
+class ApplyMessage;
+class QAbstractItemDelegate;
+class QProgressDialog;
+class QSortFilterProxyModel;
+
+namespace OstProto {
+    class SessionContent;
+}
+
+class PortsWindow : public QWidget, private Ui::PortsWindow, private Ui::StreamsWidget
+{
+    Q_OBJECT
+
+    //QAbstractItemModel    *slm; // stream list model
+    PortGroupList        *plm;
+
+public:
+    PortsWindow(PortGroupList *pgl, QWidget *parent = 0);
+    ~PortsWindow();
+
+    int portGroupCount();
+    int reservedPortCount();
+
+    bool openSession(const OstProto::SessionContent *session,
+                     QString &error);
+    bool saveSession(OstProto::SessionContent *session,
+                     QString &error,
+                     QProgressDialog *progress = NULL);
+
+signals:
+    void currentPortChanged(const QModelIndex &current,
+                            const QModelIndex &previous);
+
+private:
+    QString        lastNewPortGroup;
+    QAbstractItemDelegate *delegate;
+    QSortFilterProxyModel *proxyPortModel;
+    ApplyMessage *applyMsg_;
+
+public slots:
+    void clearCurrentSelection();
+    void showMyReservedPortsOnly(bool enabled);
+
+private slots:
+    void updateApplyHint(int portGroupId, int portId, bool configChanged);
+    void updatePortViewActions(const QModelIndex& currentIndex);
+    void updateStreamViewActions();
+
+    void on_startTx_clicked();
+    void on_stopTx_clicked();
+    void on_averagePacketsPerSec_editingFinished();
+    void on_averageBitsPerSec_editingFinished();
+    void updatePortRates();
+    void on_tvStreamList_activated(const QModelIndex & index);
+    void when_portView_currentChanged(const QModelIndex& currentIndex,
+        const QModelIndex& previousIndex);
+    void when_portModel_dataChanged(const QModelIndex& topLeft,
+        const QModelIndex& bottomRight);
+    void when_portModel_reset();
+
+    void on_pbApply_clicked();    
+
+    void on_actionNew_Port_Group_triggered();
+    void on_actionDelete_Port_Group_triggered();
+    void on_actionConnect_Port_Group_triggered();
+    void on_actionDisconnect_Port_Group_triggered();
+
+    void on_actionExclusive_Control_triggered(bool checked);
+    void on_actionPort_Configuration_triggered();
+
+    void on_actionNew_Stream_triggered();
+    void on_actionEdit_Stream_triggered();
+    void on_actionDuplicate_Stream_triggered();
+    void on_actionDelete_Stream_triggered();
+
+    void on_actionOpen_Streams_triggered();
+    void on_actionSave_Streams_triggered();
+
+    void streamModelDataChanged();
+};
+
+#endif
+

--- a/client/streamswidget.ui
+++ b/client/streamswidget.ui
@@ -14,84 +14,18 @@
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QToolButton" name="startTx">
-       <property name="toolTip">
-        <string>Start Transmit</string>
-       </property>
-       <property name="statusTip">
-        <string>Start transmit on selected port</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="ostinato.qrc">
-         <normaloff>:/icons/control_play.png</normaloff>:/icons/control_play.png</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="stopTx">
-       <property name="toolTip">
-        <string>Stop Transmit</string>
-       </property>
-       <property name="statusTip">
-        <string>Stop transmit on selected port</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="ostinato.qrc">
-         <normaloff>:/icons/control_stop.png</normaloff>:/icons/control_stop.png</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="radioButton">
-       <property name="text">
-        <string>Avg pps</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="averagePacketsPerSec"/>
-     </item>
-     <item>
-      <widget class="QRadioButton" name="radioButton_2">
-       <property name="text">
-        <string>Avg bps</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="averageBitsPerSec">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>9</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
    <item>
     <widget class="XTableView" name="tvStreamList">
      <property name="sizePolicy">
@@ -182,38 +116,5 @@ Right-click to create a stream</string>
  <resources>
   <include location="ostinato.qrc"/>
  </resources>
- <connections>
-  <connection>
-   <sender>radioButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>averagePacketsPerSec</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>326</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>454</x>
-     <y>79</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>radioButton_2</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>averageBitsPerSec</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>523</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>651</x>
-     <y>88</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/client/streamswidget.ui
+++ b/client/streamswidget.ui
@@ -1,0 +1,496 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PortsWindow</class>
+ <widget class="QWidget" name="PortsWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>663</width>
+    <height>352</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout">
+   <item row="0" column="0">
+    <widget class="QSplitter" name="splitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
+     </property>
+     <widget class="XTreeView" name="tvPortList">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="contextMenuPolicy">
+       <enum>Qt::ActionsContextMenu</enum>
+      </property>
+      <property name="selectionMode">
+       <enum>QAbstractItemView::SingleSelection</enum>
+      </property>
+     </widget>
+     <widget class="QStackedWidget" name="swDetail">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <horstretch>2</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="currentIndex">
+       <number>2</number>
+      </property>
+      <widget class="QWidget" name="blankPage">
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>&lt;p&gt;&lt;b&gt;Welcome to Ostinato!&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;The port list on the left contains all the ports on which you can transmit packets.&lt;/p&gt;
+&lt;p&gt;Ports belong to a port group. Make sure the Port Group has a &lt;img src=&quot;:/icons/bullet_green.png&quot;/&gt; next to it, then double click the port group to show or hide the ports in the port group.&lt;/p&gt;
+&lt;p&gt;To generate packets, you need to create and configure packet streams. A stream is a sequence of one or more packets.&lt;/p&gt;
+&lt;p&gt;To create a stream, select the port on which you want to send packets.&lt;/p&gt;
+&lt;hr/&gt;
+&lt;p&gt;Don't see the port that you want (or any ports at all) inside the port group? &lt;a href=&quot;https://jump.ostinato.org/noports&quot;&gt;Get Help!&lt;/a&gt;&lt;/p&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="portGroupDetail">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>&lt;p&gt;You have selected a port group in the port list on the left.&lt;/p&gt;
+&lt;p&gt;You can transmit packets on any of the ports within the port group.&lt;/p&gt;
+&lt;p&gt;Make sure the port group has a &lt;img src=&quot;:/icons/bullet_green.png&quot;/&gt; next to it and then double click the port group to show or hide the ports in the port group.&lt;/p&gt;
+&lt;p&gt;To generate packets, you need to create and configure packet streams. A stream is a sequence of one or more packets.&lt;/p&gt;
+&lt;p&gt;To create a stream, select the port on which you want to send packets. &lt;/p&gt;
+&lt;hr/&gt;
+&lt;p&gt;Don't see the port that you want (or any ports at all) inside the port group? &lt;a href=&quot;https://jump.ostinato.org/noports&quot;&gt;Get Help!&lt;/a&gt;&lt;/p&gt;</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>177</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="portDetail">
+       <layout class="QVBoxLayout">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QFrame" name="frame">
+          <property name="frameShape">
+           <enum>QFrame::Panel</enum>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Raised</enum>
+          </property>
+          <layout class="QHBoxLayout">
+           <property name="leftMargin">
+            <number>3</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>3</number>
+           </property>
+           <property name="bottomMargin">
+            <number>3</number>
+           </property>
+           <item>
+            <spacer>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="applyHint">
+             <property name="text">
+              <string>Apply Hint</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="pbApply">
+             <property name="text">
+              <string>Apply</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTabWidget" name="portConfig">
+          <property name="currentIndex">
+           <number>0</number>
+          </property>
+          <widget class="QWidget" name="streamsTab">
+           <attribute name="title">
+            <string>Streams</string>
+           </attribute>
+           <layout class="QVBoxLayout">
+            <item>
+             <layout class="QHBoxLayout">
+              <item>
+               <widget class="QToolButton" name="startTx">
+                <property name="toolTip">
+                 <string>Start Transmit</string>
+                </property>
+                <property name="statusTip">
+                 <string>Start transmit on selected port</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="ostinato.qrc">
+                  <normaloff>:/icons/control_play.png</normaloff>:/icons/control_play.png</iconset>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QToolButton" name="stopTx">
+                <property name="toolTip">
+                 <string>Stop Transmit</string>
+                </property>
+                <property name="statusTip">
+                 <string>Stop transmit on selected port</string>
+                </property>
+                <property name="text">
+                 <string/>
+                </property>
+                <property name="icon">
+                 <iconset resource="ostinato.qrc">
+                  <normaloff>:/icons/control_stop.png</normaloff>:/icons/control_stop.png</iconset>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="radioButton">
+                <property name="text">
+                 <string>Avg pps</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="averagePacketsPerSec"/>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="radioButton_2">
+                <property name="text">
+                 <string>Avg bps</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="averageBitsPerSec">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="XTableView" name="tvStreamList">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>1</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="contextMenuPolicy">
+               <enum>Qt::ActionsContextMenu</enum>
+              </property>
+              <property name="whatsThis">
+               <string>This is the stream list for the selected port
+
+A stream is a sequence of one or more packets
+
+Right-click to create a stream</string>
+              </property>
+              <property name="frameShape">
+               <enum>QFrame::StyledPanel</enum>
+              </property>
+              <property name="lineWidth">
+               <number>1</number>
+              </property>
+              <property name="selectionMode">
+               <enum>QAbstractItemView::ExtendedSelection</enum>
+              </property>
+              <property name="selectionBehavior">
+               <enum>QAbstractItemView::SelectRows</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+          <widget class="QWidget" name="devicesTab">
+           <attribute name="title">
+            <string>Devices</string>
+           </attribute>
+           <layout class="QVBoxLayout">
+            <item>
+             <widget class="DevicesWidget" name="devicesWidget" native="true"/>
+            </item>
+           </layout>
+          </widget>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+  <action name="actionNew_Port_Group">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/portgroup_add.png</normaloff>:/icons/portgroup_add.png</iconset>
+   </property>
+   <property name="text">
+    <string>New Port Group</string>
+   </property>
+  </action>
+  <action name="actionDelete_Port_Group">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/portgroup_delete.png</normaloff>:/icons/portgroup_delete.png</iconset>
+   </property>
+   <property name="text">
+    <string>Delete Port Group</string>
+   </property>
+  </action>
+  <action name="actionConnect_Port_Group">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/portgroup_connect.png</normaloff>:/icons/portgroup_connect.png</iconset>
+   </property>
+   <property name="text">
+    <string>Connect Port Group</string>
+   </property>
+  </action>
+  <action name="actionDisconnect_Port_Group">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/portgroup_disconnect.png</normaloff>:/icons/portgroup_disconnect.png</iconset>
+   </property>
+   <property name="text">
+    <string>Disconnect Port Group</string>
+   </property>
+  </action>
+  <action name="actionNew_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_add.png</normaloff>:/icons/stream_add.png</iconset>
+   </property>
+   <property name="text">
+    <string>New Stream</string>
+   </property>
+  </action>
+  <action name="actionDelete_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_delete.png</normaloff>:/icons/stream_delete.png</iconset>
+   </property>
+   <property name="text">
+    <string>Delete Stream</string>
+   </property>
+  </action>
+  <action name="actionEdit_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_edit.png</normaloff>:/icons/stream_edit.png</iconset>
+   </property>
+   <property name="text">
+    <string>Edit Stream</string>
+   </property>
+  </action>
+  <action name="actionExclusive_Control">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Exclusive Port Control (EXPERIMENTAL)</string>
+   </property>
+  </action>
+  <action name="actionOpen_Streams">
+   <property name="text">
+    <string>Open Streams ...</string>
+   </property>
+  </action>
+  <action name="actionSave_Streams">
+   <property name="text">
+    <string>Save Streams ...</string>
+   </property>
+  </action>
+  <action name="actionPort_Configuration">
+   <property name="text">
+    <string>Port Configuration ...</string>
+   </property>
+  </action>
+  <action name="actionDuplicate_Stream">
+   <property name="icon">
+    <iconset resource="ostinato.qrc">
+     <normaloff>:/icons/stream_duplicate.png</normaloff>:/icons/stream_duplicate.png</iconset>
+   </property>
+   <property name="text">
+    <string>Duplicate Stream</string>
+   </property>
+  </action>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>DevicesWidget</class>
+   <extends>QWidget</extends>
+   <header>deviceswidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>XTreeView</class>
+   <extends>QTreeView</extends>
+   <header>xtreeview.h</header>
+  </customwidget>
+  <customwidget>
+   <class>XTableView</class>
+   <extends>QTableView</extends>
+   <header>xtableview.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="ostinato.qrc"/>
+ </resources>
+ <connections>
+  <connection>
+   <sender>radioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>averagePacketsPerSec</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>326</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>454</x>
+     <y>79</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>radioButton_2</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>averageBitsPerSec</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>523</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>651</x>
+     <y>88</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/client/streamswidget.ui
+++ b/client/streamswidget.ui
@@ -1,383 +1,130 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PortsWindow</class>
- <widget class="QWidget" name="PortsWindow">
+ <class>StreamsWidget</class>
+ <widget class="QWidget" name="StreamsWidget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>663</width>
-    <height>352</height>
+    <width>602</width>
+    <height>364</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout">
-   <item row="0" column="0">
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="childrenCollapsible">
-      <bool>false</bool>
-     </property>
-     <widget class="XTreeView" name="tvPortList">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-        <horstretch>1</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="contextMenuPolicy">
-       <enum>Qt::ActionsContextMenu</enum>
-      </property>
-      <property name="selectionMode">
-       <enum>QAbstractItemView::SingleSelection</enum>
-      </property>
-     </widget>
-     <widget class="QStackedWidget" name="swDetail">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-        <horstretch>2</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="currentIndex">
-       <number>2</number>
-      </property>
-      <widget class="QWidget" name="blankPage">
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>&lt;p&gt;&lt;b&gt;Welcome to Ostinato!&lt;/b&gt;&lt;/p&gt;
-&lt;p&gt;The port list on the left contains all the ports on which you can transmit packets.&lt;/p&gt;
-&lt;p&gt;Ports belong to a port group. Make sure the Port Group has a &lt;img src=&quot;:/icons/bullet_green.png&quot;/&gt; next to it, then double click the port group to show or hide the ports in the port group.&lt;/p&gt;
-&lt;p&gt;To generate packets, you need to create and configure packet streams. A stream is a sequence of one or more packets.&lt;/p&gt;
-&lt;p&gt;To create a stream, select the port on which you want to send packets.&lt;/p&gt;
-&lt;hr/&gt;
-&lt;p&gt;Don't see the port that you want (or any ports at all) inside the port group? &lt;a href=&quot;https://jump.ostinato.org/noports&quot;&gt;Get Help!&lt;/a&gt;&lt;/p&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout">
+     <item>
+      <widget class="QToolButton" name="startTx">
+       <property name="toolTip">
+        <string>Start Transmit</string>
+       </property>
+       <property name="statusTip">
+        <string>Start transmit on selected port</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="ostinato.qrc">
+         <normaloff>:/icons/control_play.png</normaloff>:/icons/control_play.png</iconset>
+       </property>
       </widget>
-      <widget class="QWidget" name="portGroupDetail">
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QLabel" name="label_5">
-          <property name="text">
-           <string>&lt;p&gt;You have selected a port group in the port list on the left.&lt;/p&gt;
-&lt;p&gt;You can transmit packets on any of the ports within the port group.&lt;/p&gt;
-&lt;p&gt;Make sure the port group has a &lt;img src=&quot;:/icons/bullet_green.png&quot;/&gt; next to it and then double click the port group to show or hide the ports in the port group.&lt;/p&gt;
-&lt;p&gt;To generate packets, you need to create and configure packet streams. A stream is a sequence of one or more packets.&lt;/p&gt;
-&lt;p&gt;To create a stream, select the port on which you want to send packets. &lt;/p&gt;
-&lt;hr/&gt;
-&lt;p&gt;Don't see the port that you want (or any ports at all) inside the port group? &lt;a href=&quot;https://jump.ostinato.org/noports&quot;&gt;Get Help!&lt;/a&gt;&lt;/p&gt;</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-          <property name="openExternalLinks">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="verticalSpacer_2">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>177</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
+     </item>
+     <item>
+      <widget class="QToolButton" name="stopTx">
+       <property name="toolTip">
+        <string>Stop Transmit</string>
+       </property>
+       <property name="statusTip">
+        <string>Stop transmit on selected port</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="ostinato.qrc">
+         <normaloff>:/icons/control_stop.png</normaloff>:/icons/control_stop.png</iconset>
+       </property>
       </widget>
-      <widget class="QWidget" name="portDetail">
-       <layout class="QVBoxLayout">
-        <property name="leftMargin">
-         <number>0</number>
-        </property>
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <property name="rightMargin">
-         <number>0</number>
-        </property>
-        <property name="bottomMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QFrame" name="frame">
-          <property name="frameShape">
-           <enum>QFrame::Panel</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-          <layout class="QHBoxLayout">
-           <property name="leftMargin">
-            <number>3</number>
-           </property>
-           <property name="topMargin">
-            <number>3</number>
-           </property>
-           <property name="rightMargin">
-            <number>3</number>
-           </property>
-           <property name="bottomMargin">
-            <number>3</number>
-           </property>
-           <item>
-            <spacer>
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="applyHint">
-             <property name="text">
-              <string>Apply Hint</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QPushButton" name="pbApply">
-             <property name="text">
-              <string>Apply</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QTabWidget" name="portConfig">
-          <property name="currentIndex">
-           <number>0</number>
-          </property>
-          <widget class="QWidget" name="streamsTab">
-           <attribute name="title">
-            <string>Streams</string>
-           </attribute>
-           <layout class="QVBoxLayout">
-            <item>
-             <layout class="QHBoxLayout">
-              <item>
-               <widget class="QToolButton" name="startTx">
-                <property name="toolTip">
-                 <string>Start Transmit</string>
-                </property>
-                <property name="statusTip">
-                 <string>Start transmit on selected port</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="ostinato.qrc">
-                  <normaloff>:/icons/control_play.png</normaloff>:/icons/control_play.png</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QToolButton" name="stopTx">
-                <property name="toolTip">
-                 <string>Stop Transmit</string>
-                </property>
-                <property name="statusTip">
-                 <string>Stop transmit on selected port</string>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-                <property name="icon">
-                 <iconset resource="ostinato.qrc">
-                  <normaloff>:/icons/control_stop.png</normaloff>:/icons/control_stop.png</iconset>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <spacer>
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="radioButton">
-                <property name="text">
-                 <string>Avg pps</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLineEdit" name="averagePacketsPerSec"/>
-              </item>
-              <item>
-               <widget class="QRadioButton" name="radioButton_2">
-                <property name="text">
-                 <string>Avg bps</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QLineEdit" name="averageBitsPerSec">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="XTableView" name="tvStreamList">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>1</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="contextMenuPolicy">
-               <enum>Qt::ActionsContextMenu</enum>
-              </property>
-              <property name="whatsThis">
-               <string>This is the stream list for the selected port
+     </item>
+     <item>
+      <spacer>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioButton">
+       <property name="text">
+        <string>Avg pps</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="averagePacketsPerSec"/>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="radioButton_2">
+       <property name="text">
+        <string>Avg bps</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="averageBitsPerSec">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="XTableView" name="tvStreamList">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="contextMenuPolicy">
+      <enum>Qt::ActionsContextMenu</enum>
+     </property>
+     <property name="whatsThis">
+      <string>This is the stream list for the selected port
 
 A stream is a sequence of one or more packets
 
 Right-click to create a stream</string>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::StyledPanel</enum>
-              </property>
-              <property name="lineWidth">
-               <number>1</number>
-              </property>
-              <property name="selectionMode">
-               <enum>QAbstractItemView::ExtendedSelection</enum>
-              </property>
-              <property name="selectionBehavior">
-               <enum>QAbstractItemView::SelectRows</enum>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-          <widget class="QWidget" name="devicesTab">
-           <attribute name="title">
-            <string>Devices</string>
-           </attribute>
-           <layout class="QVBoxLayout">
-            <item>
-             <widget class="DevicesWidget" name="devicesWidget" native="true"/>
-            </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </widget>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
     </widget>
    </item>
   </layout>
-  <action name="actionNew_Port_Group">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/portgroup_add.png</normaloff>:/icons/portgroup_add.png</iconset>
-   </property>
-   <property name="text">
-    <string>New Port Group</string>
-   </property>
-  </action>
-  <action name="actionDelete_Port_Group">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/portgroup_delete.png</normaloff>:/icons/portgroup_delete.png</iconset>
-   </property>
-   <property name="text">
-    <string>Delete Port Group</string>
-   </property>
-  </action>
-  <action name="actionConnect_Port_Group">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/portgroup_connect.png</normaloff>:/icons/portgroup_connect.png</iconset>
-   </property>
-   <property name="text">
-    <string>Connect Port Group</string>
-   </property>
-  </action>
-  <action name="actionDisconnect_Port_Group">
-   <property name="icon">
-    <iconset resource="ostinato.qrc">
-     <normaloff>:/icons/portgroup_disconnect.png</normaloff>:/icons/portgroup_disconnect.png</iconset>
-   </property>
-   <property name="text">
-    <string>Disconnect Port Group</string>
-   </property>
-  </action>
   <action name="actionNew_Stream">
    <property name="icon">
     <iconset resource="ostinato.qrc">
@@ -405,14 +152,6 @@ Right-click to create a stream</string>
     <string>Edit Stream</string>
    </property>
   </action>
-  <action name="actionExclusive_Control">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
-   <property name="text">
-    <string>Exclusive Port Control (EXPERIMENTAL)</string>
-   </property>
-  </action>
   <action name="actionOpen_Streams">
    <property name="text">
     <string>Open Streams ...</string>
@@ -421,11 +160,6 @@ Right-click to create a stream</string>
   <action name="actionSave_Streams">
    <property name="text">
     <string>Save Streams ...</string>
-   </property>
-  </action>
-  <action name="actionPort_Configuration">
-   <property name="text">
-    <string>Port Configuration ...</string>
    </property>
   </action>
   <action name="actionDuplicate_Stream">
@@ -439,17 +173,6 @@ Right-click to create a stream</string>
   </action>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>DevicesWidget</class>
-   <extends>QWidget</extends>
-   <header>deviceswidget.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>XTreeView</class>
-   <extends>QTreeView</extends>
-   <header>xtreeview.h</header>
-  </customwidget>
   <customwidget>
    <class>XTableView</class>
    <extends>QTableView</extends>

--- a/common/protocol.proto
+++ b/common/protocol.proto
@@ -212,6 +212,9 @@ message Port {
     optional TransmitMode transmit_mode = 7 [default = kSequentialTransmit];
     optional string user_name = 8;
     optional bool is_tracking_stream_stats = 9;
+
+    optional double speed = 10; // in Mbps
+    optional uint32 mtu = 11;
 }
 
 message PortConfigList {

--- a/server/abstractport.cpp
+++ b/server/abstractport.cpp
@@ -64,6 +64,11 @@ AbstractPort::~AbstractPort()
 
 void AbstractPort::init()
 {
+    if (interfaceInfo_) {
+        data_.set_speed(interfaceInfo_->speed);
+        data_.set_mtu(interfaceInfo_->mtu);
+    }
+
     if (deviceManager_)
         deviceManager_->createHostDevices();
 }    

--- a/server/bsdport.cpp
+++ b/server/bsdport.cpp
@@ -214,8 +214,11 @@ void BsdPort::populateInterfaceInfo()
     }
 
     interfaceInfo_ = new InterfaceInfo;
-    // FIXME: speed, mtu
     interfaceInfo_->mac = mac;
+    if (mac) {
+	interfaceInfo_->speed = ((struct if_data*)addr->ifa_data)->ifi_baudrate/1e6;
+	interfaceInfo_->mtu = ((struct if_data*)addr->ifa_data)->ifi_mtu;
+    }
 
     //
     // Find gateways

--- a/server/bsdport.cpp
+++ b/server/bsdport.cpp
@@ -214,6 +214,7 @@ void BsdPort::populateInterfaceInfo()
     }
 
     interfaceInfo_ = new InterfaceInfo;
+    // FIXME: speed, mtu
     interfaceInfo_->mac = mac;
 
     //

--- a/server/drone.pro
+++ b/server/drone.pro
@@ -59,6 +59,7 @@ SOURCES += \
     bsdport.cpp \
     linuxhostdevice.cpp \
     linuxport.cpp \
+    linuxutils.cpp \
     params.cpp \
     winhostdevice.cpp \
     winpcapport.cpp 

--- a/server/interfaceinfo.h
+++ b/server/interfaceinfo.h
@@ -39,6 +39,9 @@ struct InterfaceInfo
     quint64          mac;
     QList<Ip4Config> ip4;
     QList<Ip6Config> ip6;
+
+    double speed{0}; // in Mbps
+    quint32 mtu{0};
 };
 
 #endif

--- a/server/linuxport.cpp
+++ b/server/linuxport.cpp
@@ -247,6 +247,7 @@ void LinuxPort::populateInterfaceInfo()
     rtnl_link_put(link);
 
     interfaceInfo_ = new InterfaceInfo;
+    // FIXME: speed, mtu
     interfaceInfo_->mac = mac;
 
     //

--- a/server/linuxport.cpp
+++ b/server/linuxport.cpp
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 #include "linuxport.h"
 
 #include "interfaceinfo.h"
+#include "linuxutils.h"
 
 #ifdef Q_OS_LINUX
 
@@ -243,11 +244,13 @@ void LinuxPort::populateInterfaceInfo()
         return;
     }
 
+    interfaceInfo_ = new InterfaceInfo;
+    interfaceInfo_->speed = sysfsAttrib(name(), "speed").toDouble();
+    interfaceInfo_->mtu = rtnl_link_get_mtu(link);
+
     int ifIndex = rtnl_link_get_ifindex(link);
     rtnl_link_put(link);
 
-    interfaceInfo_ = new InterfaceInfo;
-    // FIXME: speed, mtu
     interfaceInfo_->mac = mac;
 
     //

--- a/server/linuxutils.cpp
+++ b/server/linuxutils.cpp
@@ -1,0 +1,65 @@
+/*
+Copyright (C) 2021 Srivats P.
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#include "linuxutils.h"
+
+#include <QFile>
+#include <QTextStream>
+
+// Reads a text file (size < 4K) and returns content as a string
+// A terminating \n will be removed
+// There's no way to distinguish an empty file and error while reading
+QString readTextFile(QString fileName)
+{
+    QFile file(fileName);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qWarning("Can't read %s", qUtf8Printable(fileName));
+        return QString();
+    }
+
+    if (file.size() > 4096) {
+        qWarning("Can't read %s - too large (%lld)",
+                 qUtf8Printable(fileName), file.size());
+        return QString();
+    }
+
+    QTextStream in(&file);
+    QString text = in.readAll();
+    file.close();
+
+    if (text.endsWith('\n'))
+        text.chop(1);
+
+    return text;
+}
+
+// Reads value from /sys/class/net/<device>/<attrib-path>
+// and returns as string
+// XXX: reading from sysfs is discouraged
+QString sysfsAttrib(const char *device, const char *attribPath)
+{
+    return readTextFile(QString("/sys/class/net/%1/%2")
+                            .arg(device).arg(attribPath));
+}
+
+// Convenience overload
+QString sysfsAttrib(QString device, const char *attribPath)
+{
+    return sysfsAttrib(qPrintable(device), attribPath);
+}

--- a/server/linuxutils.h
+++ b/server/linuxutils.h
@@ -1,0 +1,29 @@
+/*
+Copyright (C) 2021 Srivats P.
+
+This file is part of "Ostinato"
+
+This is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+
+#ifndef _LINUX_UTILS_H
+#define _LINUX_UTILS_H
+
+#include <QString>
+
+QString readTextFile(QString fileName);
+QString sysfsAttrib(const char *device, const char *attribPath);
+QString sysfsAttrib(QString device, const char *attribPath);
+
+#endif

--- a/server/portmanager.cpp
+++ b/server/portmanager.cpp
@@ -74,7 +74,7 @@ PortManager::PortManager()
     {
         AbstractPort *port;
       
-        qDebug("%d. %s", i, device->name);
+        qDebug("==========\n%d. %s", i, device->name);
         if (device->description)
             qDebug(" (%s)\n", device->description);
 
@@ -122,6 +122,8 @@ PortManager::PortManager()
                         qPrintable(QHostAddress(ip.address.toArray()).toString()),
                         ip.prefixLength,
                         qPrintable(QHostAddress(ip.gateway.toArray()).toString()));
+            qDebug("Speed: %g Mbps", intfInfo->speed);
+            qDebug("Mtu: %u", intfInfo->mtu);
         }
 
         if (!port->setRateAccuracy(txRateAccuracy))

--- a/server/winpcapport.cpp
+++ b/server/winpcapport.cpp
@@ -263,7 +263,7 @@ void WinPcapPort::populateInterfaceInfo()
     interfaceInfo_ = new InterfaceInfo;
 
     interfaceInfo_->speed = adapter->TransmitLinkSpeed != quint64(-1) ?
-        adapter->TransmitLinkSpeed/ulong(1e6) : 0;
+        adapter->TransmitLinkSpeed/1e6 : 0;
     interfaceInfo_->mtu = adapter->Mtu;
 
     if (adapter->PhysicalAddressLength == 6) {

--- a/server/winpcapport.cpp
+++ b/server/winpcapport.cpp
@@ -261,6 +261,11 @@ void WinPcapPort::populateInterfaceInfo()
     }
 
     interfaceInfo_ = new InterfaceInfo;
+
+    interfaceInfo_->speed = adapter->TransmitLinkSpeed != quint64(-1) ?
+        adapter->TransmitLinkSpeed/ulong(1e6) : 0;
+    interfaceInfo_->mtu = adapter->Mtu;
+
     if (adapter->PhysicalAddressLength == 6) {
         interfaceInfo_->mac = qFromBigEndian<quint64>(
                                     adapter->PhysicalAddress) >> 16;


### PR DESCRIPTION
![FD7RMrYVIAwxrVT](https://user-images.githubusercontent.com/8395079/143077369-afb6399d-50c5-4191-b6dc-728db64340c9.png)

- [x] Display Port Speed
- [x] Enter rate as % of port speed (aka load)
- [x] Auto change bit rate units to _bps_, _kbps_, _mbps_, _gbps_ (but not for frame rate)
- [x] Allow units to be specified during input as well (for both frame rate and bit rate)

Frame rate is shown only in _pps_ to enable high resolution e.g. 1,488,095.2381 pps instead of 1.4881 Mpps